### PR TITLE
Separate fetch and merge steps in the pulling operation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,9 @@ interactive workflows to perform bulk operations on your packages.
 
 * To pull from each package's configured remote, run `M-x
   straight-pull-package` or `M-x straight-pull-all`. To also pull from
-  the upstream, if one is configured, provide a prefix argument.
+  the upstream, if one is configured, provide a prefix argument. The
+  fetch and merge steps can be separated using the commands
+  `straight-fetch-package` and `straight-merge-package` (or `-all`).
 
 * To push all local changes to each package's configured remote, run
   `M-x straight-push-package` or `M-x straight-push-all`.
@@ -1529,6 +1531,11 @@ a backend API method. The relevant methods are:
   generally means reverting it to a standard state, such as a clean
   working directory, but does not entail checking out any particular
   commit).
+* `fetch`: given a recipe, fetch all remotes for its repository.
+* `merge-from-remote`: given a recipe, merge the latest version of the
+  repository from its configured, already fetched remote.
+* `merge-from-upstream`: same as `merge-from-remote` but using the
+  upstream remote.
 * `pull-from-remote`: given a recipe, pull the latest version of the
   repository from its configured remote, if one is specified.
 * `pull-from-upstream`: given a recipe, pull the latest version of the
@@ -1584,6 +1591,14 @@ the version-control backend API:
 * `normalize`: verifies that remote URLs are set correctly, that no
   merge is in progress, that the worktree is clean, and that the
   primary `:branch` is checked out.
+* `fetch`: check that remote URLs are set correctly, then
+  `git fetch --all`.
+* `merge-from-remote`: performs normalization, then if the local copy
+  of the primary remote is ahead of the primary branch prompts the
+  user to merge it.
+* `merge-from-upstream`: performs normalization, then if the local
+  copy of the upstream remote (if there is one) is ahead of the
+  primary branch prompts the user to merge it.
 * `pull-from-remote`: performs normalization, then pulls from the
   primary remote and merges with the primary `:branch`.
 * `pull-from-upstream`: performs normalization, then pulls from the
@@ -1830,6 +1845,13 @@ follows:
 
 * `M-x straight-normalize-package`: normalize a package
 * `M-x straight-normalize-all`: normalize all packages
+* `M-x straight-fetch-package`: fetch from all remotes of a package
+* `M-x straight-fetch-all`: fetch from all remotes of all packages
+* `M-x straight-merge-package`: merge from a package's configure
+  remote; with prefix argument, also merge from upstream if present.
+  This uses only locally available information prealably obtained e.g.
+  by `straight-fetch-package`.
+* `M-x straight-merge-all`: `straight-merge-package` on all packages.
 * `M-x straight-pull-package`: pull from a package's configured
   remote; with prefix argument, also pull from upstream if present
 * `M-x straight-pull-all`: pull from all packages' configured remotes;

--- a/straight.el
+++ b/straight.el
@@ -639,6 +639,30 @@ specified in RECIPE."
     (let ((straight--default-directory (straight--dir "repos" local-repo)))
       (straight-vc 'normalize type recipe))))
 
+(defun straight-vc-fetch (recipe)
+  "Pull from all remotes for straight.el-style RECIPE.
+
+This method sets `straight--default-directory' to the local
+repository directory and delegates to the relevant
+`straight-vc-TYPE-pull-from-remote' method, where TYPE is the
+`:type' specified in RECIPE."
+  (straight--with-plist recipe
+      (local-repo type)
+    (let ((straight--default-directory (straight--dir "repos" local-repo)))
+      (straight-vc 'fetch type recipe))))
+
+(defun straight-vc-merge-from-remote (recipe)
+  "Merge from the primary remote for straight.el-style RECIPE.
+
+This method sets `straight--default-directory' to the local
+repository directory and delegates to the relevant
+`straight-vc-TYPE-merge-from-remote' method, where TYPE is the
+`:type' specified in RECIPE."
+  (straight--with-plist recipe
+      (local-repo type)
+    (let ((straight--default-directory (straight--dir "repos" local-repo)))
+      (straight-vc 'merge-from-remote type recipe))))
+
 (defun straight-vc-pull-from-remote (recipe)
   "Pull from the primary remote for straight.el-style RECIPE.
 
@@ -650,6 +674,19 @@ repository directory and delegates to the relevant
       (local-repo type)
     (let ((straight--default-directory (straight--dir "repos" local-repo)))
       (straight-vc 'pull-from-remote type recipe))))
+
+(defun straight-vc-merge-from-upstream (recipe)
+  "Merge from the upstream remote for straight.el-style RECIPE.
+If there is no upstream configured, this method does nothing.
+
+This method sets `straight--default-directory' to the local
+repository directory and delegates to the relevant
+`straight-vc-TYPE-merge-from-upstream' method, where TYPE is the
+`:type' specified in RECIPE."
+  (straight--with-plist recipe
+      (local-repo type)
+    (let ((straight--default-directory (straight--dir "repos" local-repo)))
+      (straight-vc 'merge-from-upstream type recipe))))
 
 (defun straight-vc-pull-from-upstream (recipe)
   "Pull from the upstream remote for straight.el-style RECIPE.
@@ -1154,6 +1191,20 @@ confirmation, so this function should only be run after
                                (straight--get-call
                                 "git" "reset" "--hard" ref-name)))))))))))))))
 
+(cl-defun straight-vc-git--merge-from-remote-raw (recipe remote remote-branch)
+  "Using straight.el-style RECIPE, merge from REMOTE.
+REMOTE is a string. REMOTE-BRANCH is the branch in REMOTE that is
+used; it should be a string that is not prefixed with a remote
+name."
+  (straight--with-plist recipe
+      (local-repo branch)
+    (let ((branch (or branch straight-vc-git-default-branch)))
+      (while t
+        (and (straight-vc-git--validate-local recipe)
+             (straight-vc-git--validate-head
+              local-repo branch (format "%s/%s" remote remote-branch))
+             (cl-return-from straight-vc-git--merge-from-remote-raw t))))))
+
 (cl-defun straight-vc-git--pull-from-remote-raw (recipe remote remote-branch)
   "Using straight.el-style RECIPE, pull from REMOTE.
 REMOTE is a string. REMOTE-BRANCH is the branch in REMOTE that is
@@ -1286,6 +1337,33 @@ primary :branch is checked out."
     (and (straight-vc-git--validate-local recipe)
          (cl-return-from straight-vc-git-normalize t))))
 
+(cl-defun straight-vc-git-fetch (recipe)
+  "Using straight.el-style RECIPE, fetch all remotes."
+  (while t
+    (and (straight-vc-git--validate-remotes recipe)
+         (straight--get-call "git" "fetch" "--all")
+         (cl-return-from straight-vc-git-fetch t))))
+
+(cl-defun straight-vc-git-merge-from-remote (recipe &optional from-upstream)
+  "Using straight.el-style RECIPE, merge from a remote.
+If FROM-UPSTREAM is non-nil, merge from the upstream remote,
+unless no :upstream is configured, in which case do nothing. Else
+merge from the primary remote."
+  (straight--with-plist recipe
+      (branch upstream)
+    (unless (and from-upstream (null upstream))
+      (let* ((remote (if from-upstream
+                         straight-vc-git-upstream-remote
+                       straight-vc-git-primary-remote))
+             (branch (or branch straight-vc-git-default-branch))
+             (remote-branch
+              (if from-upstream
+                  (or (plist-get upstream :branch)
+                      straight-vc-git-default-branch)
+                branch)))
+        (straight-vc-git--merge-from-remote-raw
+         recipe remote remote-branch)))))
+
 (cl-defun straight-vc-git-pull-from-remote (recipe &optional from-upstream)
   "Using straight.el-style RECIPE, pull from a remote.
 If FROM-UPSTREAM is non-nil, pull from the upstream remote,
@@ -1305,6 +1383,12 @@ pull from the primary remote."
                 branch)))
         (straight-vc-git--pull-from-remote-raw
          recipe remote remote-branch)))))
+
+(defun straight-vc-git-merge-from-upstream (recipe)
+  "Using straight.el-style RECIPE, merge from upstream.
+If no upstream is configured, do nothing."
+  (straight-vc-git-merge-from-remote
+   recipe straight-vc-git-upstream-remote))
 
 (defun straight-vc-git-pull-from-upstream (recipe)
   "Using straight.el-style RECIPE, pull from upstream.
@@ -3123,6 +3207,75 @@ non-nil if the package should actually be normalized."
   (interactive)
   (straight--map-repos-interactively #'straight-normalize-package
                                      predicate))
+
+;;;###autoload
+(defun straight-fetch-package (package)
+  "Try to fetch a PACKAGE from all remotes.
+PACKAGE is a string naming a package. Interactively, select
+PACKAGE from the known packages in the current Emacs session
+using `completing-read'."
+  (interactive (list (straight--select-package "Fetch package")))
+  (let ((recipe (gethash package straight--recipe-cache)))
+    (straight-vc-fetch recipe)))
+
+;;;###autoload
+(defun straight-fetch-all (&optional predicate)
+  "Try to fetch all packages (with fetch --all).
+
+Return a list of recipes for packages that were not successfully
+pulled. If multiple packages come from the same local repository,
+only one is pulled.
+
+PREDICATE, if provided, filters the packages that are normalized.
+It is called with the package name as a string, and should return
+non-nil if the package should actually be normalized."
+  (interactive)
+  (straight--map-repos-interactively
+   (lambda (package)
+     (straight-fetch-package package))
+   predicate))
+
+;;;###autoload
+(defun straight-merge-package (package &optional from-upstream)
+  "Try to merge a PACKAGE from the primary remote.
+Remotes are assumed to have been fetched previously, by
+`straight-fetch-all' or manually, so no network operation is
+done.
+
+PACKAGE is a string naming a package. Interactively, select
+PACKAGE from the known packages in the current Emacs session
+using `completing-read'. With prefix argument FROM-UPSTREAM,
+merge not just from primary remote but also from configured
+upstream."
+  (interactive (list (straight--select-package "Merge package")
+                     current-prefix-arg))
+  (let ((recipe (gethash package straight--recipe-cache)))
+    (and (straight-vc-merge-from-remote recipe)
+         (when from-upstream
+           (straight-vc-merge-from-upstream recipe)))))
+
+;;;###autoload
+(defun straight-merge-all (&optional from-upstream predicate)
+  "Try to merge all packages from their primary remotes.
+Remotes are assumed to have been fetched previously, by
+`straight-fetch-all' or manually, so no network operation is
+done.
+
+With prefix argument FROM-UPSTREAM, merge not just from primary
+remotes but also from configured upstreams.
+
+Return a list of recipes for packages that were not successfully
+merged. If multiple packages come from the same local repository,
+only one is merged.
+
+PREDICATE, if provided, filters the packages that are merged.
+It is called with the package name as a string, and should return
+non-nil if the package should actually be merged."
+  (interactive "P")
+  (straight--map-repos-interactively
+   (lambda (package)
+     (straight-merge-package package from-upstream))
+   predicate))
 
 ;;;###autoload
 (defun straight-pull-package (package &optional from-upstream)


### PR DESCRIPTION
The primary motivation is to be able to fetch all packages without
interrupting for user interaction (which takes network dependent time)
then in a separate step merge (which requires user interaction even if
only to hit the fast-forward button).

In a more conventional package manager these steps would be called
`update` and `upgrade` ;)

Depending on feedback the `pull` vc operations may be removed with the
high level pull-package and pull-all implemented in terms of fetch and
merge.