### PR TITLE
Add Edebug specs

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -353,7 +353,7 @@ alist, to ensure correct results."
 PROPS is a list of symbols. Each one is converted to a keyword
 and then its value is looked up in the PLIST and bound to the
 symbol for the duration of BODY."
-  (declare (indent 2))
+  (declare (indent 2) (debug (form sexp body)))
   (let ((plist-sym (make-symbol "plist")))
     `(let* ((,plist-sym ,plist)
             ,@(mapcar (lambda (prop)
@@ -511,7 +511,7 @@ are displayed. TASK can also be a cons, whose car and cdr are
 used as the TASK for the beginning and end messages
 respectively. (Either the car or cdr, or both, can be nil.) See
 also `straight--progress-begin' and `straight--progress-end'."
-  (declare (indent 1))
+  (declare (indent 1) (debug t))
   (let ((task-sym (make-symbol "gensym--task"))
         (task-car-sym (make-symbol "gensym--task-car"))
         (task-cdr-sym (make-symbol "gensym--task-cdr")))
@@ -965,7 +965,7 @@ have been performed, even if there was an error."
 
 (defmacro straight-transaction (&rest body)
   "Eval BODY within transaction. Return value is result of last form in BODY."
-  (declare (indent defun))
+  (declare (indent defun) (debug t))
   `(progn
      (straight-begin-transaction)
      (unwind-protect (progn ,@body)


### PR DESCRIPTION
I'm trying to figure out how `straight-use-package` / `straight--build-package` works with Edebug, but it can't step inside macros due to lacking the Edebug specs.