### PR TITLE
[#220] Build info manual from source directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 dist: trusty
-sudo: false
+sudo: required
 env:
   - EVM_VERSION=24.4
   - EVM_VERSION=24.5
   - EVM_VERSION=25.1
   - EVM_VERSION=25.2
   - EVM_VERSION=25.3
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y texinfo
 
 install:
   - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 dist: trusty
-sudo: required
+sudo: false
+addons:
+  apt:
+    packages:
+    - texinfo
 env:
   - EVM_VERSION=24.4
   - EVM_VERSION=24.5
   - EVM_VERSION=25.1
   - EVM_VERSION=25.2
   - EVM_VERSION=25.3
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y texinfo
 
 install:
   - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - texinfo
+      - texinfo
 env:
   - EVM_VERSION=24.4
   - EVM_VERSION=24.5

--- a/straight.el
+++ b/straight.el
@@ -3425,7 +3425,8 @@ repository."
         (let ((dir (straight--build-file package "dir")))
           (unless (file-exists-p dir)
             (dolist (info infos)
-              (straight--warn-call "install-info" info dir))))))))
+              (when (file-exists-p info)
+                (straight--warn-call "install-info" info dir)))))))))
 
 ;;;;; Cache handling
 

--- a/straight.el
+++ b/straight.el
@@ -3425,7 +3425,7 @@ repository."
           (when-let ((infos (straight--directory-files
                              default-directory "\\.info$")))
             (dolist (info infos)
-              (straight--check-call "install-info" info "dir"))))))))
+              (straight--warn-call "install-info" info "dir"))))))))
 
 ;;;;; Cache handling
 

--- a/straight.el
+++ b/straight.el
@@ -3408,24 +3408,24 @@ repository."
              (executable-find "install-info"))
     (straight--with-plist recipe
         (package local-repo files)
-      (pcase-dolist (`(,repo-file . ,build-file)
-                     (straight-expand-files-directive
-                      files
-                      (straight--repos-dir local-repo)
-                      (straight--build-dir package)))
-        (when (string-match-p ".texi\\(nfo\\)?$" repo-file)
-          (let ((texi repo-file)
-                (info (concat (file-name-sans-extension build-file) ".info")))
-            (unless (file-exists-p info)
-              (let ((default-directory (file-name-directory texi)))
-                (apply #'straight--warn-call
-                       "makeinfo" texi "-o" info '()))))))
-      (let ((default-directory (straight--build-dir package)))
-        (unless (file-exists-p "dir")
-          (when-let ((infos (straight--directory-files
-                             default-directory "\\.info$")))
+      (let (infos)
+        (pcase-dolist (`(,repo-file . ,build-file)
+                       (straight-expand-files-directive
+                        files
+                        (straight--repos-dir local-repo)
+                        (straight--build-dir package)))
+          (when (string-match-p ".texi\\(nfo\\)?$" repo-file)
+            (let ((texi repo-file)
+                  (info (concat (file-name-sans-extension build-file) ".info")))
+              (push info infos)
+              (unless (file-exists-p info)
+                (let ((default-directory (file-name-directory texi)))
+                  (apply #'straight--warn-call
+                         "makeinfo" texi "-o" info '()))))))
+        (let ((dir (straight--build-file package "dir")))
+          (unless (file-exists-p dir)
             (dolist (info infos)
-              (straight--warn-call "install-info" info "dir"))))))))
+              (straight--warn-call "install-info" info dir))))))))
 
 ;;;;; Cache handling
 

--- a/straight.el
+++ b/straight.el
@@ -3416,7 +3416,8 @@ repository."
                         (straight--build-dir package)))
           (when (string-match-p ".texi\\(nfo\\)?$" repo-file)
             (let ((texi repo-file)
-                  (info (concat (file-name-sans-extension build-file) ".info")))
+                  (info
+                   (concat (file-name-sans-extension build-file) ".info")))
               (push info infos)
               (unless (file-exists-p info)
                 (let ((default-directory (file-name-directory texi)))

--- a/straight.el
+++ b/straight.el
@@ -3413,7 +3413,7 @@ repository."
                       files
                       (straight--repos-dir local-repo)
                       (straight--build-dir package)))
-        (when (string-match ".texi\\(nfo\\)?$" repo-file)
+        (when (string-match-p ".texi\\(nfo\\)?$" repo-file)
           (let ((texi repo-file)
                 (info (concat (file-name-sans-extension build-file) ".info")))
             (unless (file-exists-p info)


### PR DESCRIPTION
This is my attempt to fix #200, which is inspired by Melpa's [package-build--generate-info-files](https://github.com/melpa/package-build/blob/fc706968dc0bb60e06c5d21025a6ea82d3279e96/package-build.el#L792) function.