### PR TITLE
Support :straight (pkg-a pkg-b) syntax in use-package

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4588,8 +4588,17 @@ documentation."
        ((symbolp arg) (push arg parsed-args))
        ((not (listp arg))
         (use-package-error ":straight wants a symbol or list"))
-       ((keywordp (car arg)) (push (cons name-symbol arg) parsed-args))
-       (t (push arg parsed-args))))
+       ((keywordp (car arg))
+        ;; recipe without package name
+        (push (cons name-symbol arg) parsed-args))
+       ((cl-some #'keywordp arg)
+        ;; assume it's a recipe
+        (push arg parsed-args))
+       (t
+        (setq parsed-args
+              (append parsed-args
+                      (straight-use-package--straight-normalizer
+                       name-symbol nil arg))))))
     parsed-args))
 
 (defun straight-use-package--straight-handler


### PR DESCRIPTION
Previously this resulted in an error because it expanded
to (straight-use-package '(pkg-a pkg-b)).

Sorry, I had a git issue on my local repo and just recreated the branch, which I guess github doesn't like. 