### PR TITLE
Refactor pull operations to use fetch and merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,10 +1577,6 @@ a backend API method. The relevant methods are:
   fetched from the configured remote, if any, to the local copy.
 * `merge-from-upstream`: given a recipe, merge the latest version
   fetched from the configured upstream, if any, to the local copy.
-* `pull-from-remote`: given a recipe, pull the latest version of the
-  repository from its configured remote, if one is specified.
-* `pull-from-upstream`: given a recipe, pull the latest version of the
-  repository from its configured upstream, if one is specified.
 * `push-to-remote`: given a recipe, push the current version of the
   repository to its configured remote, if one is specified.
 * `check-out-commit`: given a local repository name and a commit
@@ -1619,7 +1615,7 @@ These are the keywords meaningful for the `git` backend:
   particularly important for the EmacsMirror recipe repository, which
   contains every known Emacs package in existence as submodules.
 * `:upstream`: a plist which specifies settings for an upstream, if
-  desired. This is meaningful for the `pull-from-upstream` method. The
+  desired. This is meaningful for the `fetch-from-upstream` method. The
   allowed keywords are `:repo`, `:host`, and `:branch`.
 
 This section tells you how the `git` backend, specifically, implements
@@ -1640,11 +1636,6 @@ the version-control backend API:
   primary remote into the primary local `:branch`.
 * `merge-from-upstream`: performs normalization, then merges from the
   upstream remote into the primary local `:branch`.
-* `pull-from-remote`: performs normalization, then pulls from the
-  primary remote and merges with the primary `:branch`.
-* `pull-from-upstream`: performs normalization, then pulls from the
-  configured `:upstream`, if there is one. Merges with the primary
-  `:branch`.
 * `push-to-remote`: performs normalization, pulls from the primary
   remote if necessary, and then pushes if necessary.
 * `check-out-commit`: verifies that no merge is in progress and that

--- a/straight.el
+++ b/straight.el
@@ -1183,39 +1183,6 @@ repository directory and delegates to the relevant
       (let ((straight--default-directory (straight--repos-dir local-repo)))
         (straight-vc 'merge-from-upstream type recipe)))))
 
-(defun straight-vc-pull-from-remote (recipe)
-  "Pull from the primary remote for straight.el-style RECIPE.
-
-If the RECIPE does not specify a local repository, then no action
-is taken.
-
-This method sets `straight--default-directory' to the local
-repository directory and delegates to the relevant
-`straight-vc-TYPE-pull-from-remote' method, where TYPE is the
-`:type' specified in RECIPE."
-  (straight--with-plist recipe
-      (local-repo type)
-    (when local-repo
-      (let ((straight--default-directory (straight--repos-dir local-repo)))
-        (straight-vc 'pull-from-remote type recipe)))))
-
-(defun straight-vc-pull-from-upstream (recipe)
-  "Pull from the upstream remote for straight.el-style RECIPE.
-If there is no upstream configured, this method does nothing.
-
-If the RECIPE does not specify a local repository, then no action
-is taken.
-
-This method sets `straight--default-directory' to the local
-repository directory and delegates to the relevant
-`straight-vc-TYPE-pull-from-upstream' method, where TYPE is the
-`:type' specified in RECIPE."
-  (straight--with-plist recipe
-      (local-repo type)
-    (when local-repo
-      (let ((straight--default-directory (straight--repos-dir local-repo)))
-        (straight-vc 'pull-from-upstream type recipe)))))
-
 (defun straight-vc-push-to-remote (recipe)
   "Push to the primary remote for straight.el-style RECIPE, if necessary.
 
@@ -1745,20 +1712,9 @@ name."
 REMOTE is a string. REMOTE-BRANCH is the branch in REMOTE that is
 used; it should be a string that is not prefixed with a remote
 name."
-  (straight--with-plist recipe
-      (local-repo branch)
-    (let ((branch (or branch straight-vc-git-default-branch))
-          (already-fetched nil))
-      (while t
-        (and (straight-vc-git--validate-local recipe)
-             (or already-fetched
-                 (progn
-                   (straight--get-call
-                    "git" "fetch" remote)
-                   (setq already-fetched t)))
-             (straight-vc-git--validate-head
-              local-repo branch (format "%s/%s" remote remote-branch))
-             (cl-return-from straight-vc-git--pull-from-remote-raw t))))))
+  (straight-vc-git-fetch-from-remote recipe)
+  (straight-vc-git--merge-from-remote-raw
+   recipe remote remote-branch))
 
 (cl-defun straight-vc-git--ensure-head-pushed
     (recipe)
@@ -1939,34 +1895,6 @@ part of the VC API."
   "Using straight.el-style RECIPE, merge from upstream.
 If no upstream is configured, do nothing."
   (straight-vc-git-merge-from-remote recipe 'from-upstream))
-
-(cl-defun straight-vc-git-pull-from-remote (recipe &optional from-upstream)
-  "Using straight.el-style RECIPE, pull from a remote.
-If FROM-UPSTREAM is non-nil, pull from the upstream remote,
-unless no :upstream is configured, in which case do nothing. Else
-pull from the primary remote."
-  (unless (plist-member recipe :repo)
-    (cl-return-from straight-vc-git-pull-from-remote t))
-  (straight--with-plist recipe
-      (branch upstream)
-    (unless (and from-upstream (null upstream))
-      (let* ((remote (if from-upstream
-                         straight-vc-git-upstream-remote
-                       straight-vc-git-primary-remote))
-             (branch (or branch straight-vc-git-default-branch))
-             (remote-branch
-              (if from-upstream
-                  (or (plist-get upstream :branch)
-                      straight-vc-git-default-branch)
-                branch)))
-        (straight-vc-git--pull-from-remote-raw
-         recipe remote remote-branch)))))
-
-(defun straight-vc-git-pull-from-upstream (recipe)
-  "Using straight.el-style RECIPE, pull from upstream.
-If no upstream is configured, do nothing."
-  (straight-vc-git-pull-from-remote
-   recipe straight-vc-git-upstream-remote))
 
 (cl-defun straight-vc-git-push-to-remote (recipe)
   "Using straight.el-style RECIPE, push to primary remote, if necessary."
@@ -4223,9 +4151,11 @@ not just from primary remote but also from configured upstream."
   (interactive (list (straight--select-package "Pull package" nil 'installed)
                      current-prefix-arg))
   (let ((recipe (gethash package straight--recipe-cache)))
-    (and (straight-vc-pull-from-remote recipe)
+    (and (straight-vc-fetch-from-remote recipe)
+         (straight-vc-merge-from-remote recipe)
          (when from-upstream
-           (straight-vc-pull-from-upstream recipe)))))
+           (and (straight-vc-fetch-from-upstream recipe)
+                (straight-vc-merge-from-upstream recipe))))))
 
 ;;;###autoload
 (defun straight-pull-all (&optional from-upstream predicate)
@@ -4241,10 +4171,8 @@ PREDICATE, if provided, filters the packages that are pulled. It
 is called with the package name as a string, and should return
 non-nil if the package should actually be pulled."
   (interactive "P")
-  (straight--map-existing-repos-interactively
-   (lambda (package)
-     (straight-pull-package package from-upstream))
-   predicate))
+  (straight-fetch-all from-upstream predicate)
+  (straight-merge-all from-upstream predicate))
 
 ;;;###autoload
 (defun straight-push-package (package)

--- a/straight.el
+++ b/straight.el
@@ -1224,7 +1224,7 @@ is taken.
 
 This method sets `straight--default-directory' to the local
 repository directory and delegates to the relevant
-`straight-vc-TYPE-pull-from-remote' method, where TYPE is the
+`straight-vc-TYPE-push-to-remote' method, where TYPE is the
 `:type' specified in RECIPE."
   (straight--with-plist recipe
       (local-repo type)


### PR DESCRIPTION
`straight-pull-all` now feches first, before merging all.

I've removed the low-level git pull commands as they're functionally covered by fetch and merge, and keeping the VC interface as simple as possible seems like a good idea.

Addresses some of #103