### PR TITLE
el-get can also specify git revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,10 +1155,6 @@ offer corrections for this section.
 
 #### Advantages of `straight.el`
 
-* `straight.el` has integrated support for selecting particular Git
-  revisions of packages. This process is more manual in el-get, as it
-  requires placing the commit hash into the recipe, which disables
-  updates.
 * `straight.el` uses your init-file as the sole source of truth for
   package operations. el-get has additional metadata stored outside
   the init-file, although specifying all packages in your init-file is


### PR DESCRIPTION
`el-get` allows to specify a git revision, a branch or a tag. For example:

```lisp
(setq el-get-sources
      '((:name org-mode
               :checkout "release_9.1.13")
        (:name cider
               :checkout "v0.17.0")
        (:name clojure-mode
               :checkout "5.8.1")
        (:name bbdb
               :checkout "c951e15cd01d")
        (:name magit
               :checkout "2.13.0")))
```

Note I may have misunderstood the point. As a long time el-get user, other points seem valid to me.