### PR TITLE
[wip] configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,17 +1344,30 @@ care of all these details for you:
 
 <!-- longlines-start -->
 
-    (let ((bootstrap-file
-           (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
-          (bootstrap-version 4))
-      (unless (file-exists-p bootstrap-file)
-        (with-current-buffer
-            (url-retrieve-synchronously
-             "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
-             'silent 'inhibit-cookies)
-          (goto-char (point-max))
-          (eval-print-last-sexp)))
-      (load bootstrap-file nil 'nomessage))
+    ;; optional customization
+    ;(defvar straight--project-base-url "https://raw.githubusercontent.com/<example>/straight.el/")
+    ;(defvar straight--base-dir (concat user-emacs-directory "some/alternative/path"))
+
+    ;; bootstrap
+    (let*
+      ((straight--project-base-url (if (bound-and-true-p straight--project-base-url)
+                                         straight--project-base-url
+                                       "https://raw.githubusercontent.com/raxod502/straight.el/"))
+       (straight--base-dir (if (bound-and-true-p straight--base-dir)
+                               straight--base-dir
+                             (concat user-emacs-directory "straight/")))
+       (bootstrap-file (concat straight--base-dir "repos/straight.el/bootstrap.el"))
+       (bootstrap-version 4))
+    (unless (file-exists-p bootstrap-file)
+      (progn
+        (require 'load-mode__straight-install)
+      (with-current-buffer
+          (url-retrieve-synchronously
+           (concat straight--project-base-url "develop/install.el")
+           'silent 'inhibit-cookies)
+        (goto-char (point-max))
+        (eval-print-last-sexp)))
+    (load bootstrap-file nil 'nomessage))
 
 <!-- longlines-stop -->
 

--- a/bootstrap.el
+++ b/bootstrap.el
@@ -112,7 +112,7 @@
 
 ;; Then we register (and build) straight.el itself.
 (straight-use-package `(straight :type git :host github
-                                 :repo "raxod502/straight.el"
+                                 :repo "nickgarber/straight.el"
                                  :files ("straight*.el")
                                  :branch ,straight-repository-branch))
 

--- a/straight.el
+++ b/straight.el
@@ -40,7 +40,7 @@
 
 (require 'cl-lib)
 (require 'subr-x)
-(require 'straight-compat)
+;disabled-to-avoid-error-during-bootstrap;(require 'straight-compat)
 
 ;;;; Functions from other packages
 
@@ -435,12 +435,12 @@ and postpended to the straight directory.
   "Get a subdirectory of the straight/ directory.
 SEGMENTS are passed to `straight--emacs-dir'. With no SEGMENTS,
 return the straight/ directory itself."
-  (apply #'straight--emacs-dir "straight" segments))
+  (apply #'straight--emacs-dir "var/cache/straight" segments))
 
 (defun straight--file (&rest segments)
   "Get a file in the straight/ directory.
 SEGMENTS are passed to `straight--emacs-file'."
-  (apply #'straight--emacs-file "straight" segments))
+  (apply #'straight--emacs-file "var/cache/straight" segments))
 
 (defun straight--build-dir (&rest segments)
   "Get a subdirectory of the straight/build/ directory.


### PR DESCRIPTION
relates to https://github.com/raxod502/straight.el/issues/274

* Goals:

- [ ] determine optimal location and handling for the override variables `straight--project-base-url` and `straight--base-dir`
- [x] enable use of a package like https://github.com/emacscollective/no-littering
- [ ] support configurable paths, (without requiring the project be forked)
- [ ] (optionally) allow for different paths per profile. [1]


[1] I'm interested in having a full-featured 'workstation' profile, a 'minimal' profile, and a 'presentation' profile. By separating the paths it would support very stable configurations even while switching between profiles, even potentially running multiple profiles simultaneously.
