### PR TITLE
Document symlink setup on MS Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,10 +1587,34 @@ recipes which do not explicitly specify a `:no-autoloads` attribute.
 Usually, `straight.el` uses symbolic links ("symlinks") to make
 package files available from the build directory. This happens when
 `straight-use-symlinks` is non-nil, the default. On Microsoft Windows,
-however, there is no support for symlinks, so the default value of
-`straight-use-symlinks` is nil on that platform. That causes copying
-to be used instead, and an advice is placed on `find-file` to cause
-the copied files to act as symlinks if you try to edit them.
+however, support for symlinks is not always available, so the default
+value of `straight-use-symlinks` is nil on that platform. That causes
+copying to be used instead, and an advice is placed on `find-file` to
+cause the copied files to act as symlinks if you try to edit them.
+
+If you want to activate symlink support on MS Windows 7, 8, or 10, the
+following information may be helpful:
+
+* `straight-use-symlinks` has to be set to non-nil manually
+
+* Your user-account needs to be assigned the right to create symbolic
+  links. To do so, run "secpol.msc" and in "Local Policies → User
+  Rights Assignment" assign the right to "Create symbolic links" to
+  your user-account.
+
+* If you have User Account Control (UAC) enabled and your user-account
+  belongs to the the _Administrators_ group you'll need to run Emacs
+  in elevated mode to be able to create symlinks (see
+  [here](https://community.perforce.com/s/article/3472) and
+  [here](https://stackoverflow.com/questions/29063916/win32api-symlink-creation-issue-with-uac-enabled#29065060)
+  and, for an official reference, section Access Token Changes [in
+  this
+  document](https://msdn.microsoft.com/en-us/library/bb530410.aspx#vistauac_topic8)
+
+* [Windows Creators
+  Update](https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/)
+  supports symlink creation without any special permission setup
+
 
 #### Customizing how packages are made available
 

--- a/README.md
+++ b/README.md
@@ -1592,10 +1592,10 @@ value of `straight-use-symlinks` is nil on that platform. That causes
 copying to be used instead, and an advice is placed on `find-file` to
 cause the copied files to act as symlinks if you try to edit them.
 
-If you want to activate symlink support on MS Windows 7, 8, or 10, the
-following information may be helpful:
+If you want to activate symlink-support on MS Windows 7, 8, or 10, you
+should ensure the following requirements:
 
-* `straight-use-symlinks` has to be set to non-nil manually
+* `straight-use-symlinks` has to be set to non-nil manually.
 
 * Your user-account needs to be assigned the right to create symbolic
   links. To do so, run "secpol.msc" and in "Local Policies → User
@@ -1605,15 +1605,12 @@ following information may be helpful:
 * If you have User Account Control (UAC) enabled and your user-account
   belongs to the the _Administrators_ group you'll need to run Emacs
   in elevated mode to be able to create symlinks (see
-  [here](https://community.perforce.com/s/article/3472) and
-  [here](https://stackoverflow.com/questions/29063916/win32api-symlink-creation-issue-with-uac-enabled#29065060)
-  and, for an official reference, section Access Token Changes [in
-  this
-  document](https://msdn.microsoft.com/en-us/library/bb530410.aspx#vistauac_topic8)
+  [here][symlinks-perforce] and [here][symlinks-stackoverflow] and,
+  for an official reference, section Access Token Changes [in this
+  document][symlinks-microsoft].
 
-* [Windows Creators
-  Update](https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/)
-  supports symlink creation without any special permission setup
+* [Windows Creators Update][symlinks-creators] supports
+  symlink-creation without any special permission setup.
 
 
 #### Customizing how packages are made available
@@ -2720,6 +2717,10 @@ version of Org provides, and that a correctly built version of Org
 [radian]: https://github.com/raxod502/radian
 [quelpa]: https://github.com/quelpa/quelpa
 [spacemacs]: http://spacemacs.org/
+[symlinks-creators]: https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/
+[symlinks-microsoft]: https://msdn.microsoft.com/en-us/library/bb530410.aspx#vistauac_topic8
+[symlinks-perforce]: https://community.perforce.com/s/article/3472
+[symlinks-stackoverflow]: https://stackoverflow.com/questions/29063916/win32api-symlink-creation-issue-with-uac-enabled#29065060
 [tag-only-issue]: https://github.com/raxod502/straight.el/issues/31
 [travis-badge]: https://travis-ci.org/raxod502/straight.el.svg?branch=develop
 [travis-build]: https://travis-ci.org/raxod502/straight.el

--- a/straight.el
+++ b/straight.el
@@ -613,19 +613,22 @@ Otherwise, return nil."
 This means that they are used to build packages rather than
 copying files, which is slower and less space-efficient.
 
-All operating systems support symlinks except for older versions
-of Microsoft Windows (before Windows Vista)."
+All operating systems support symlinks; however, on Microsoft
+Windows you may need additional system configuration (see
+variable `straight-use-symlinks')."
   (not (memq system-type '(ms-dos windows-nt cygwin))))
 
 (defcustom straight-use-symlinks (straight--symlinks-are-usable-p)
   "Whether to use symlinks for building packages.
 Using symlinks is always preferable.
 
-On Microsoft Windows, this variable has to be set to true
+On Microsoft Windows, this variable has to be set to non-nil
 manually, if desired, as symlink-functionality is not always
 available. On most versions of Windows 10, the user's account
 needs to be assigned the right to \"Create symbolic links\" in
-\"secpol.msc\".
+\"secpol.msc\". For more information about the symlink-setup on
+MS Windows please refer to the section \"Customizing how packages
+are built\" in the user manual.
 
 Beware that copying is slower, less space-efficient, and
 requiring of additional hacks."

--- a/straight.el
+++ b/straight.el
@@ -613,15 +613,22 @@ Otherwise, return nil."
 This means that they are used to build packages rather than
 copying files, which is slower and less space-efficient.
 
-All operating systems support symlinks except Microsoft Windows."
+All operating systems support symlinks except for older versions
+of Microsoft Windows (before Windows Vista)."
   (not (memq system-type '(ms-dos windows-nt cygwin))))
 
 (defcustom straight-use-symlinks (straight--symlinks-are-usable-p)
   "Whether to use symlinks for building packages.
-Using symlinks is always preferable, unless you use Microsoft
-Windows, in which you will have to use copying instead. This is
-slower, less space-efficient, and requiring of additional hacks,
-but such is Windows."
+Using symlinks is always preferable.
+
+On Microsoft Windows, this variable has to be set to true
+manually, if desired, as symlink-functionality is not always
+available. On most versions of Windows 10, the user's account
+needs to be assigned the right to \"Create symbolic links\" in
+\"secpol.msc\".
+
+Beware that copying is slower, less space-efficient, and
+requiring of additional hacks."
   :type 'boolean)
 
 (defun straight--directory-files (&optional directory match full sort)


### PR DESCRIPTION
Actually symlinks are supported on windows; it's just a bit weird that you have
to assign permission to the user. This patch detects if the user has the ability
to create symlinks and then conditionally activates their usage in straight.

The rant about MS Windows would have to fall victim to this patch.