### PR TITLE
Fix bug when cloning with :fork

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -1974,12 +1974,12 @@ specified in RECIPE instead. If that fails, signal a warning."
             (straight--get-call
              "git" "clone" "--origin" upstream-remote
              "--no-checkout" url local-repo)
-            (when fork-repo
-              (let ((url (straight-vc-git--encode-url fork-repo fork-host)))
-                (straight--get-call "git" "remote" "add" fork-remote url)
-                (straight--get-call "git" "fetch" fork-remote)))
             (let ((straight--default-directory nil)
                   (default-directory repo-dir))
+              (when fork-repo
+                (let ((url (straight-vc-git--encode-url fork-repo fork-host)))
+                  (straight--get-call "git" "remote" "add" fork-remote url)
+                  (straight--get-call "git" "fetch" fork-remote)))
               (when commit
                 (unless (straight--check-call "git" "checkout" commit)
                   (straight--warn


### PR DESCRIPTION
The shell command to `git remote add fork` needs to happen in the
context of the package's repo, and previously this was happening in
`straight/repos`, which is usually the user's `.emacs.d` repo. The first
time it does this, it doesn't fail, since you can add the fork remote to
the repo; but the second time (for another recipe with a fork), it
finally fails because fork already exists as a remote. Both of these
executions are incorrect anyway, because it should be done in the cloned
repo of the package. Fortunately, fixing this is as easy as moving the
logic down, such that `default-directory` is set to `repo-dir`.