### PR TITLE
Fix org-version == "N/A" error

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5356,6 +5356,7 @@ Inserted by installing org-mode or when a release is made."
                "--abbrev=0"
                "HEAD")))))))
 
+    (defconst org-version (org-version))
     (provide 'org-version)))
 
 (if straight-fix-org


### PR DESCRIPTION
I tried to install org-journal using straight (current develop branch with the org hack), but installation did not succeed due to the following error:

```
Error (use-package): org-journal/:catch: Invalid version syntax: ‘N/A’ (must start with a number)
```

The issue seems to be that org-mode assigns the result of `(org-version)` statically to [the constant with the same name as the function](https://code.orgmode.org/bzg/org-mode/src/master/lisp/org.el#L350). The result of `(org-version)` at that point is "N/A". org-journal [reads that constant](https://github.com/bastibe/org-journal/blob/bca2c39c692f7c58dbbe03698748187f87822043/org-journal.el#L68) and fails to get the proper version number.

The attached commit fixes the issue for me. However, elisp is not within my usual comfort zone, so there might be better ways to do it.