### PR TITLE
Add option for shallow clones (--depth N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,6 +1799,11 @@ These are the keywords meaningful for the `git` backend:
   you can use the `fetch-from-upstream` method to operate on the
   upstream instead. The allowed keywords are `:repo`, `:host`,
   `:branch`, and `:remote`.
+* `:depth`: either the symbol `full` or an integer. If `full`, then
+  the repository is cloned with its whole history. If an integer `N`,
+  then the repository is cloned with the option `--depth N`, unless a
+  commit is specified (e.g. by version lockfiles). The default value
+  is `full`.
 
 This section tells you how the `git` backend, specifically, implements
 the version-control backend API:
@@ -1861,6 +1866,11 @@ You can customize the following user options:
   will quietly do fast-forward, to suppress asking for instructions on
   each package with updates, unless they're not trivial. Set to nil if
   you'd prefer to inspect all changes.
+* `straight-vc-git-default-clone-depth`: the default value for the
+  `:depth` keyword. It can be either the symbol `full` or an integer,
+  and defaults to `full`. Setting this variable to a small integer will
+  reduce the size of repositories. Note that this variable does *not*
+  affect packages whose versions are locked.
 
 ##### Deprecated `:upstream` keyword
 

--- a/install.el
+++ b/install.el
@@ -85,7 +85,7 @@
 
   (let (;; This needs to have a default value, just in case the user
         ;; doesn't have any lockfiles.
-        (version :uranus)
+        (version :neptune)
         (straight-profiles (if (boundp 'straight-profiles)
                                straight-profiles
                              '((nil . "default")))))

--- a/straight.el
+++ b/straight.el
@@ -1957,24 +1957,24 @@ If this fails, try again to clone without the option --depth and --branch,
 as a fallback."
   (cond
    ((eq depth 'full)
-    ;; clone the whole history of the repository
+    ;; Clone the whole history of the repository.
     (straight--get-call
      "git" "clone" "--origin" upstream-remote
      "--no-checkout" url repo-dir))
    ((integerp depth)
-    ;; shallow clone
+    ;; Do a shallow clone.
     (condition-case err
         (straight--get-call
          "git" "clone" "--origin" upstream-remote
          "--no-checkout" url repo-dir
          "--depth" (number-to-string depth)
          "--branch" branch)
-      ;; fallback for dumb http protocol
+      ;; Fallback for dumb http protocol.
       (error (straight-vc-git--clone-internal :depth 'full
                                               :upstream-remote upstream-remote
                                               :url url
                                               :repo-dir repo-dir))))
-   (t (error "Invalid value %s of depth for %s" depth url))))
+   (t (error "Invalid value %S of depth for %s" depth url))))
 
 ;;;;;; API
 

--- a/straight.el
+++ b/straight.el
@@ -5010,7 +5010,7 @@ according to the value of `straight-profiles'."
               ;;
               ;; The version keyword comes after the versions alist so
               ;; that you can ignore it if you don't need it.
-              "(%s)\n:uranus\n"
+              "(%s)\n:neptune\n"
               (mapconcat
                (apply-partially #'format "%S")
                versions-alist

--- a/straight.el
+++ b/straight.el
@@ -1963,7 +1963,7 @@ as a fallback."
      "--no-checkout" url repo-dir))
    ((integerp depth)
     ;; Do a shallow clone.
-    (condition-case err
+    (condition-case nil
         (straight--get-call
          "git" "clone" "--origin" upstream-remote
          "--no-checkout" url repo-dir

--- a/straight.el
+++ b/straight.el
@@ -1948,7 +1948,8 @@ unless a commit is specified (e.g. by version lockfiles). "
   :group 'straight
   :type '(choice integer (const full)))
 
-(cl-defun straight-vc-git--clone-internal (&key depth upstream-remote url repo-dir branch)
+(cl-defun straight-vc-git--clone-internal
+    (&key depth upstream-remote url repo-dir branch)
   "Clone a remote repository from URL.
 
 If DEPTH is the symbol `full', clone the whole history of the repository.

--- a/straight.el
+++ b/straight.el
@@ -1944,7 +1944,7 @@ with the remotes."
 The value should be the symbol `full' or an integer. If the value
 is `full', clone the whole history of repositories. If the value is
 an integer N, remote repositories are cloned with the option --depth N,
-unless a commit is specified (e.g. by version lockfiles). "
+unless a commit is specified (e.g. by version lockfiles)."
   :group 'straight
   :type '(choice integer (const full)))
 

--- a/straight.el
+++ b/straight.el
@@ -1997,9 +1997,6 @@ specified in RECIPE instead. If that fails, signal a warning."
                      straight-vc-git-default-clone-depth)))
       (unwind-protect
           (progn
-            ;; (straight--get-call
-            ;;  "git" "clone" "--origin" upstream-remote
-            ;;  "--no-checkout" url repo-dir)
             (straight-vc-git--clone-internal :depth depth
                                              :upstream-remote upstream-remote
                                              :url url


### PR DESCRIPTION
This PR adds option for shallow clone (`--depth N`), only for packages whose versions are *not* locked.

- This PR resolves #2 *partially*.
- This PR is based on #284.
  I was thinking whether to continue #284, but I decided to create a new PR because #284 is too old to merge today.

I really want an option for shallow clones, but, unfortunately, it is difficult to treat version locking as discussed in #2. So I implemented an option for shallow clones only for packages whose versions are not locked.
Of cource, I know this implementation is far from complete, but it is useful at least for me (and hopefully some of other people).

I welcome any kind of comments, including disagreement.

### Usage
Note that, if you add nothing in your `init.el`, then this PR does nothing.

```elisp
;; Change the default value of the option
(setq straight-vc-git-default-clone-depth 1)

;; Change the option for a single package, say `lsp-mode'
(straight-register-package
 '(lsp-mode :type git :host github
            :repo "emacs-lsp/lsp-mode"
            :depth full))
(straight-use-package 'lsp-mode)
```

The value of the option `:depth` or `straight-vc-git-default-clone-depth` can be the following:

- the symbol `full`, which means clone *without* `--depth` option
  (This is the defualt value)
- an integer `N`, which means clone with the option `--depth N`

### Implementation
This PR changes the function `straight-vc-git-clone`.

- If the argument `commit` is non-`nil` (some SHA-1 hash), then this PR changes nothing. Hence use `git clone` as before.
- If the argument `commit` is `nil`, then use `git clone` with the option `--depth`.

This works well even if some branch is specified in `recipe`, since the option `--branch` is added to `git clone`.

### Fallback for dumb http protocol
As far as I know, dumb http protocol does not support `--depth` option. Hence, for a packages provided by dumb http protocol, the command `git clone --depth` fails. As a fallback, I wrote the error-handler in `condition-case` in `straight-vc-git--clone-internal`.
Of cource, `straight.el` will send requests twice in this case, so it will be slower than before. But I ignored this performance issue, because very few packages are provided by dumb http protocol, I believe.
(I found only one package, `paredit`, using dumb http protocol among 90 packages which I use)
