### PR TITLE
straight-thaw-versions ergonomics improvements: auto-fetch, no decapitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2668,8 +2668,7 @@ UX of this situation.
 ### The interactive version-control operations are confusing
 
 This part of `straight.el` still needs some work; see [#54] about the
-UX of pushing and pulling, and [#58] about commits not being available
-when thawing a lockfile.
+UX of pushing and pulling.
 
 ### How do I pin package versions or use only tagged releases?
 
@@ -2686,6 +2685,14 @@ with Emacs, rather than cloning the upstream repository:
 [Read more.][#user/recipes]
 
 ## News
+### May 1, 2019
+
+`straight-thaw-versions` now fetches in a repository if a commit in
+your lockfile can not be found and normalizes the repository to the
+recipe's default branch. This should ensure that versions you have
+frozen can be quickly restored and that they can also be saved back to
+the version lock file. This addresses issues [#58], [#66], and [#294].
+
 ### March 15, 2019
 
 `straight.el` [now installs a hack for Org by

--- a/README.md
+++ b/README.md
@@ -2240,11 +2240,9 @@ make sure to check out the specified revisions of each package when
 cloning them for the first time.
 
 To install the versions of the packages specified in your version
-lockfiles, run `M-x straight-thaw-versions`. You may need to run `M-x
-straight-fetch-all` first to ensure that you have those versions
-available. Thawing will interactively check for local changes before
-checking out the relevant revisions, so don't worry about things
-getting overwritten.
+lockfiles, run `M-x straight-thaw-versions`. Thawing will
+interactively check for local changes before checking out the relevant
+revisions, so don't worry about things getting overwritten.
 
 #### The profile system
 

--- a/README.md
+++ b/README.md
@@ -1743,6 +1743,9 @@ a backend API method. The relevant methods are:
 
 * `clone`: given a recipe and a commit object, clone the repository
   and attempt to check out the given commit.
+* `commit-present-p`: given a recipe and a commit object, return
+  whether the commit can be checked out offline, i.e., without
+  fetching from the remote.
 * `normalize`: given a recipe, "normalize" the repository (this
   generally means reverting it to a standard state, such as a clean
   working directory, but does not entail checking out any particular
@@ -1813,6 +1816,8 @@ the version-control backend API:
   your revision lockfile, or the `:branch` (from the `:fork`
   configuration, if given), or `origin/HEAD`. If a `:fork` is
   specified, also fetches from the upstream.
+* `commit-present-p`: checks if the commit SHA is among the revisions
+  that are present locally.
 * `normalize`: verifies that remote URLs are set correctly, that no
   merge is in progress, that the worktree is clean, and that the
   primary `:branch` (from the `:fork` configuration, if given) is
@@ -1833,7 +1838,8 @@ the version-control backend API:
   remote if necessary, and then pushes if necessary. This operation
   acts on the fork, if the package is forked.
 * `check-out-commit`: verifies that no merge is in progress and that
-  the worktree is clean, then checks out the specified commit.
+  the worktree is clean, then resets the worktree to the specified
+  commit.
 * `get-commit`: returns HEAD as a 40-character string.
 * `local-repo-name`: if `:host` is non-nil, then `:repo` will be of
   the form "username/repository", and "repository" is used. Otherwise,

--- a/README.md
+++ b/README.md
@@ -1761,8 +1761,8 @@ a backend API method. The relevant methods are:
   the local copy.
 * `push-to-remote`: given a recipe, push the current version of the
   repository to its configured remote, if one is specified.
-* `check-out-commit`: given a local repository name and a commit
-  object, attempt to check out that commit.
+* `check-out-commit`: given a recipe and a commit object, attempt to
+  check out that commit in the repository for that recipe.
 * `get-commit`: given a local repository name, return the commit
   object that is currently checked out.
 * `local-repo-name`: given a recipe, return a good name for the local

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ chat][gitter-badge]][gitter]
   * [How do I pin package versions or use only tagged releases?](#how-do-i-pin-package-versions-or-use-only-tagged-releases)
   * [How can I use the built-in version of a package?](#how-can-i-use-the-built-in-version-of-a-package)
 - [News](#news)
+  * [May 1, 2019](#may-1-2019)
   * [March 15, 2019](#march-15-2019)
   * [December 22, 2018](#december-22-2018)
   * [September 12, 2018](#september-12-2018)

--- a/straight.el
+++ b/straight.el
@@ -1216,6 +1216,13 @@ repository directory and delegates to the relevant
   (let ((straight--default-directory (straight--repos-dir local-repo)))
     (straight-vc 'check-out-commit type local-repo commit)))
 
+(defun straight-vc-commit-present-p (recipe commit)
+  "Check if COMMIT can be checked out without fetching it in RECIPE."
+  (straight--with-plist recipe
+      (local-repo type)
+    (let ((straight--default-directory (straight--repos-dir local-repo)))
+      (straight-vc 'commit-present-p type local-repo commit))))
+
 (defun straight-vc-get-commit (type local-repo)
   "Using VC backend TYPE, in LOCAL-REPO, return current commit.
 TYPE is a symbol like symbol `git', etc. LOCAL-REPO is a string
@@ -2116,6 +2123,14 @@ is a 40-character string identifying a Git commit."
            (straight-vc-git--ensure-worktree local-repo)
            (straight--get-call "git" "checkout" commit)
            (cl-return)))))
+
+(cl-defun straight-vc-git-commit-present-p (local-repo commit)
+  (cl-block nil
+    (while t
+      (and (straight-vc-git--ensure-nothing-in-progress local-repo)
+           (cl-return
+            (straight--check-call
+             "git" "rev-parse" "-q" "--verify" (format "%s^{commit}" commit)))))))
 
 (defun straight-vc-git-get-commit (_local-repo)
   "Return the current commit for the current local repository.

--- a/straight.el
+++ b/straight.el
@@ -5050,7 +5050,7 @@ according to the value of `straight-profiles'."
              (when-let ((commit (cdr (assoc local-repo versions-alist))))
                (straight-vc-normalize recipe)
                (unless (straight-vc-commit-present-p recipe commit)
-                 (straight-vc-fetch-from-upstream recipe))
+                 (straight-vc-fetch-from-remote recipe))
                (straight-vc-check-out-commit
                 type local-repo commit)))))))))
 

--- a/straight.el
+++ b/straight.el
@@ -1203,8 +1203,8 @@ repository directory and delegates to the relevant
       (let ((straight--default-directory (straight--repos-dir local-repo)))
         (straight-vc 'push-to-remote type recipe)))))
 
-(defun straight-vc-check-out-commit (type local-repo commit)
-  "Using VC backend TYPE, in LOCAL-REPO, check out COMMIT.
+(defun straight-vc-check-out-commit (recipe commit)
+  "Normalize the repo for RECIPE and check out COMMIT.
 TYPE is a symbol like symbol `git', etc. LOCAL-REPO is a string
 naming a local package repository. The interpretation of COMMIT
 is defined by the backend, but it should be compatible with
@@ -1213,8 +1213,10 @@ is defined by the backend, but it should be compatible with
 This method sets `straight--default-directory' to the local
 repository directory and delegates to the relevant
 `straight-vc-TYPE-check-out-commit'."
-  (let ((straight--default-directory (straight--repos-dir local-repo)))
-    (straight-vc 'check-out-commit type local-repo commit)))
+  (straight--with-plist recipe
+      (local-repo type)
+      (let ((straight--default-directory (straight--repos-dir local-repo)))
+        (straight-vc 'check-out-commit type recipe commit))))
 
 (defun straight-vc-commit-present-p (recipe commit)
   "Check in RECIPE's repo if COMMIT can be checked out without fetching it.
@@ -2113,17 +2115,20 @@ If RECIPE does not configure a fork, do nothing."
   "Using straight.el-style RECIPE, push to primary remote, if necessary."
   (straight-vc-git--ensure-head-pushed recipe))
 
-(cl-defun straight-vc-git-check-out-commit (local-repo commit)
-  "In LOCAL-REPO, check out COMMIT.
-LOCAL-REPO is a string naming a local package repository. COMMIT
-is a 40-character string identifying a Git commit."
-  (straight-register-repo-modification local-repo)
-  (cl-block nil
-    (while t
-      (and (straight-vc-git--ensure-nothing-in-progress local-repo)
-           (straight-vc-git--ensure-worktree local-repo)
-           (straight--get-call "git" "reset" "--hard" commit)
-           (cl-return)))))
+(cl-defun straight-vc-git-check-out-commit (recipe commit)
+  "In RECIPE's repo, normalize and check out COMMIT.
+RECIPE is a straight recipe definition. COMMIT is a 40-character
+string identifying a Git commit."
+  (straight-vc-git--destructure recipe
+      (local-repo)
+    (straight-register-repo-modification local-repo)
+    (cl-block nil
+      (while t
+        (and (straight-vc-git--ensure-nothing-in-progress local-repo)
+             (straight-vc-git--ensure-worktree local-repo)
+             (straight-vc-git--ensure-local recipe)
+             (straight--get-call "git" "reset" "--hard" commit)
+             (cl-return))))))
 
 (cl-defun straight-vc-git-commit-present-p (_local-repo commit)
   "Return non-nil if LOCAL-REPO has COMMIT present locally."
@@ -5044,15 +5049,13 @@ according to the value of `straight-profiles'."
        (let ((recipe (gethash package straight--recipe-cache)))
          (when (straight--repository-is-available-p recipe)
            (straight--with-plist recipe
-               (type local-repo)
+               (local-repo)
              ;; We can't use `alist-get' here because that uses
              ;; `eq', and our hash-table keys are strings.
              (when-let ((commit (cdr (assoc local-repo versions-alist))))
-               (straight-vc-normalize recipe)
                (unless (straight-vc-commit-present-p recipe commit)
                  (straight-vc-fetch-from-remote recipe))
-               (straight-vc-check-out-commit
-                type local-repo commit)))))))))
+               (straight-vc-check-out-commit recipe commit)))))))))
 
 ;;;; Integration with other packages
 ;;;;; package.el "integration"

--- a/straight.el
+++ b/straight.el
@@ -2121,7 +2121,7 @@ is a 40-character string identifying a Git commit."
     (while t
       (and (straight-vc-git--ensure-nothing-in-progress local-repo)
            (straight-vc-git--ensure-worktree local-repo)
-           (straight--get-call "git" "checkout" commit)
+           (straight--get-call "git" "reset" "--hard" commit)
            (cl-return)))))
 
 (cl-defun straight-vc-git-commit-present-p (local-repo commit)

--- a/straight.el
+++ b/straight.el
@@ -2129,8 +2129,8 @@ is a 40-character string identifying a Git commit."
     (while t
       (and (straight-vc-git--ensure-nothing-in-progress local-repo)
            (cl-return
-            (straight--check-call
-             "git" "rev-parse" "-q" "--verify" (format "%s^{commit}" commit)))))))
+            (straight--check-call "git" "rev-parse" "-q" "--verify"
+                                  (format "%s^{commit}" commit)))))))
 
 (defun straight-vc-git-get-commit (_local-repo)
   "Return the current commit for the current local repository.

--- a/straight.el
+++ b/straight.el
@@ -2125,13 +2125,10 @@ is a 40-character string identifying a Git commit."
            (straight--get-call "git" "reset" "--hard" commit)
            (cl-return)))))
 
-(cl-defun straight-vc-git-commit-present-p (local-repo commit)
-  (cl-block nil
-    (while t
-      (and (straight-vc-git--ensure-nothing-in-progress local-repo)
-           (cl-return
-            (straight--check-call "git" "rev-parse" "-q" "--verify"
-                                  (format "%s^{commit}" commit)))))))
+(cl-defun straight-vc-git-commit-present-p (_local-repo commit)
+  "Return non-nil if LOCAL-REPO has COMMIT present locally."
+  (straight--check-call "git" "rev-parse" "-q" "--verify"
+                        (format "%s^{commit}" commit)))
 
 (defun straight-vc-git-get-commit (_local-repo)
   "Return the current commit for the current local repository.

--- a/straight.el
+++ b/straight.el
@@ -1205,18 +1205,21 @@ repository directory and delegates to the relevant
 
 (defun straight-vc-check-out-commit (recipe commit)
   "Normalize the repo for RECIPE and check out COMMIT.
-TYPE is a symbol like symbol `git', etc. LOCAL-REPO is a string
-naming a local package repository. The interpretation of COMMIT
-is defined by the backend, but it should be compatible with
-`straight-vc-get-commit'.
+
+If RECIPE does not specify a local repository, then no action is
+taken.
+
+The interpretation of COMMIT is defined by the backend, but it
+should be compatible with `straight-vc-get-commit'.
 
 This method sets `straight--default-directory' to the local
 repository directory and delegates to the relevant
 `straight-vc-TYPE-check-out-commit'."
   (straight--with-plist recipe
       (local-repo type)
+    (when local-repo
       (let ((straight--default-directory (straight--repos-dir local-repo)))
-        (straight-vc 'check-out-commit type recipe commit))))
+        (straight-vc 'check-out-commit type recipe commit)))))
 
 (defun straight-vc-commit-present-p (recipe commit)
   "Check in RECIPE's repo if COMMIT can be checked out without fetching it.

--- a/straight.el
+++ b/straight.el
@@ -5050,6 +5050,8 @@ according to the value of `straight-profiles'."
              ;; We can't use `alist-get' here because that uses
              ;; `eq', and our hash-table keys are strings.
              (when-let ((commit (cdr (assoc local-repo versions-alist))))
+               (unless (straight-vc-commit-present-p recipe commit)
+                 (straight-vc-fetch-from-upstream recipe))
                (straight-vc-check-out-commit
                 type local-repo commit)))))))))
 

--- a/straight.el
+++ b/straight.el
@@ -5050,6 +5050,7 @@ according to the value of `straight-profiles'."
              ;; We can't use `alist-get' here because that uses
              ;; `eq', and our hash-table keys are strings.
              (when-let ((commit (cdr (assoc local-repo versions-alist))))
+               (straight-vc-normalize recipe)
                (unless (straight-vc-commit-present-p recipe commit)
                  (straight-vc-fetch-from-upstream recipe))
                (straight-vc-check-out-commit

--- a/straight.el
+++ b/straight.el
@@ -1217,7 +1217,8 @@ repository directory and delegates to the relevant
     (straight-vc 'check-out-commit type local-repo commit)))
 
 (defun straight-vc-commit-present-p (recipe commit)
-  "Check if COMMIT can be checked out without fetching it in RECIPE."
+  "Check in RECIPE's repo if COMMIT can be checked out without fetching it.
+Returns non-nil if the commit is available."
   (straight--with-plist recipe
       (local-repo type)
     (let ((straight--default-directory (straight--repos-dir local-repo)))

--- a/straight.el
+++ b/straight.el
@@ -1223,7 +1223,7 @@ repository directory and delegates to the relevant
 
 (defun straight-vc-commit-present-p (recipe commit)
   "Check in RECIPE's repo if COMMIT can be checked out without fetching it.
-Returns non-nil if the commit is available."
+Return non-nil if the commit is available."
   (straight--with-plist recipe
       (local-repo type)
     (let ((straight--default-directory (straight--repos-dir local-repo)))


### PR DESCRIPTION
This PR is kinda a catch-all for the things that I found that were ... not ideal with thawing:

* #294 - freezing after thawing is not a no-op
* #66 - thawing leaves detached HEADs around
* #58 - thawing requires fetching beforehand

I think the attached change solves all of these in a fairly neat way,
and I hope you think so too (and that I didn't miss some subtle
interaction!).

`straight-vc-git-check-out-commit` now normalizes the local repo when checking out a commit.

`straight-thaw-versions` now:

* Tries to ensure that the commit that we're thawing to is present by checking it's there, and if not, fetching.
* Uses a new and revamped check-out-commit function that `resets --hard` instead of running `checkout`.

With this change, I managed to thaw and re-freeze the versions (with an updated repro case from #294), and they were stable!

I've also updated the README to not mention having to fetch before a freeze, as freeze does that automatically now.

Hope this is reasonable!