### PR TITLE
Fix symlink unpriviledged in windows

### DIFF
--- a/install.el
+++ b/install.el
@@ -186,14 +186,14 @@
                    ;; This is a relative symlink. It won't break if you
                    ;; (for some silly reason) move your
                    ;; `user-emacs-directory'.
-                   (target (concat "repos/" local-repo "/bootstrap.el"))
-                   (linkname (concat user-emacs-directory
+                   (link-target (concat "repos/" local-repo "/bootstrap.el"))
+                   (link-name (concat user-emacs-directory
                                      "straight/bootstrap.el")))
               (ignore-errors
                 ;; If it's a directory, the linking will fail. Just let
                 ;; the user deal with it in that case, since they are
                 ;; doing something awfully weird.
-                (delete-file linkname))
+                (delete-file link-name))
               ;; Unfortunately, there appears to be no way to get
               ;; `make-symbolic-link' to overwrite an existing file,
               ;; like 'ln -sf'. Providing the OK-IF-ALREADY-EXISTS
@@ -201,11 +201,15 @@
               ;; existing file. That's why we have to `delete-file'
               ;; above.
               (if straight-use-symlinks
-                  (make-symbolic-link target linkname)
-                (with-temp-file linkname
+                  (if (executable-find "cmd")
+                      (call-process "cmd" nil nil nil "/c" "mklink"
+                                    (replace-regexp-in-string "/" "\\" link-name t t)
+                                    (replace-regexp-in-string "/" "\\" link-target t t))
+                    (make-symbolic-link link-target link-name))
+                (with-temp-file link-name
                   (print
                    `(load (expand-file-name
-                           ,target (file-name-directory load-file-name))
+                           ,link-target (file-name-directory load-file-name))
                           nil 'nomessage)
                    (current-buffer)))))))
        (current-buffer))

--- a/install.el
+++ b/install.el
@@ -203,8 +203,8 @@
               (if straight-use-symlinks
                   (if (executable-find "cmd")
                       (call-process "cmd" nil nil nil "/c" "mklink"
-                                    (replace-regexp-in-string "/" "\\" link-name t t)
-                                    (replace-regexp-in-string "/" "\\" link-target t t))
+                                    (subst-char-in-string ?/ ?\\ link-name)
+                                    (subst-char-in-string ?/ ?\\ link-target))
                     (make-symbolic-link link-target link-name))
                 (with-temp-file link-name
                   (print

--- a/straight.el
+++ b/straight.el
@@ -646,7 +646,7 @@ SORT has been inverted from `directory-files'. Finally, the . and
                             full match (not sort)))))
 
 (defun straight--symlink-recursively (link-target link-name)
-  "Make a symbolic link to LINK-TARGET, named LINKNAME, recursively.
+  "Make a symbolic link to LINK-TARGET, named LINK-NAME, recursively.
 This means that if the link target is a directory, then a
 corresponding directory is created (called LINK-NAME) and all
 descendants of LINK-TARGET are linked separately into
@@ -667,7 +667,11 @@ be interpreted later as a symlink."
     (make-directory (file-name-directory link-name) 'parents)
     (condition-case _
         (if straight-use-symlinks
-            (make-symbolic-link link-target link-name)
+            (if (executable-find "cmd")
+                (call-process "cmd" nil nil nil "/c" "mklink"
+                              (replace-regexp-in-string "/" "\\" link-name t t)
+                              (replace-regexp-in-string "/" "\\" link-target t t))
+              (make-symbolic-link link-target link-name))
           (copy-file link-target link-name)
           (let ((build-dir (straight--build-dir)))
             (when (straight--path-prefix-p build-dir link-name)

--- a/straight.el
+++ b/straight.el
@@ -669,8 +669,8 @@ be interpreted later as a symlink."
         (if straight-use-symlinks
             (if (executable-find "cmd")
                 (call-process "cmd" nil nil nil "/c" "mklink"
-                              (replace-regexp-in-string "/" "\\" link-name t t)
-                              (replace-regexp-in-string "/" "\\" link-target t t))
+                              (subst-char-in-string ?/ ?\\ link-name)
+                              (subst-char-in-string ?/ ?\\ link-target))
               (make-symbolic-link link-target link-name))
           (copy-file link-target link-name)
           (let ((build-dir (straight--build-dir)))


### PR DESCRIPTION
>* [Windows Creators Update](https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/) supports  symlink-creation without any special permission setup.

This is not entirely correct for `Emacs` implementation of `make-symbolic-link`.
It seems that when calling `CreateSymbolicLink`, `Emacs` needs to add a new flag `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE` for symlink can be created unpriviledged in Developer mode.

I've created a mitigation by using `mklink` command which works independently from `Emacs` implementation and supported in Windows.