### PR TITLE
Ensure Package-Requires is case-insensitive

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3956,7 +3956,8 @@ this run of straight.el)."
                  ;; really need is the dependency alist. If it's
                  ;; missing or malformed, we just assume the package
                  ;; has no dependencies.
-                 (re-search-forward "^;; Package-Requires: ")
+                 (let ((case-fold-search t))
+                   (re-search-forward "^;; Package-Requires: "))
                  (when (looking-at "(")
                    (straight--process-dependencies
                     (read (current-buffer)))))))))


### PR DESCRIPTION
When emacs (27 at least) is byte-compiling `case-fold-search` is `nil` and searches become case-sensitive.
Certain packages don't capitalize "Package-Requires" because package.el is case-insensitive. For example, [dired-subtree](https://github.com/Fuco1/dired-hacks/blob/master/dired-subtree.el) uses "Package-requires".

This causes some package with uncommon capitalization to not have their dependencies handled by straight.el inside `eval-when-compile`.

Set `case-fold-search` to `t` in the header parser to ensure it's always searched for case-insensitively.