### PR TITLE
Implement configurable base path

### DIFF
--- a/install.el
+++ b/install.el
@@ -88,7 +88,9 @@
         (version :pluto)
         (straight-profiles (if (boundp 'straight-profiles)
                                straight-profiles
-                             '((nil . "default")))))
+                             '((nil . "default"))))
+        (straight-install-dir (or (bound-and-true-p straight-base-dir)
+                                  user-emacs-directory)))
     ;; The only permissible error here is for a lockfile to be absent
     ;; entirely. Anything else triggers an abort so that we don't
     ;; accidentally do something the user doesn't expect (like if they
@@ -96,7 +98,7 @@
     ;; the recipe specification, and forgot to update which repository
     ;; their init-file downloaded install.el from).
     (dolist (lockfile-name (mapcar #'cdr straight-profiles))
-      (let ((lockfile-path (concat user-emacs-directory
+      (let ((lockfile-path (concat straight-install-dir
                                    "straight/versions/"
                                    lockfile-name)))
         (when (file-exists-p lockfile-path)
@@ -184,7 +186,7 @@
                    ;; (for some silly reason) move your
                    ;; `user-emacs-directory'.
                    (link-target (concat "repos/" local-repo "/bootstrap.el"))
-                   (link-name (concat user-emacs-directory
+                   (link-name (concat straight-install-dir
                                       "straight/bootstrap.el")))
               (ignore-errors
                 ;; If it's a directory, the linking will fail. Just let

--- a/install.el
+++ b/install.el
@@ -85,7 +85,7 @@
 
   (let (;; This needs to have a default value, just in case the user
         ;; doesn't have any lockfiles.
-        (version :pluto)
+        (version :alpha)
         (straight-profiles (if (boundp 'straight-profiles)
                                straight-profiles
                              '((nil . "default"))))

--- a/straight-x.el
+++ b/straight-x.el
@@ -152,7 +152,7 @@
   (let ((lockfile-path (straight--versions-lockfile 'pinned)))
     (with-temp-file lockfile-path
       (insert
-       (format "(%s)\n:pluto\n"
+       (format "(%s)\n:alpha\n"
                (mapconcat
                 (apply-partially #'format "%S")
                 straight-x-pinned-packages

--- a/straight.el
+++ b/straight.el
@@ -5265,7 +5265,7 @@ according to the value of `straight-profiles'."
               ;; keyword will be updated. It tells install.el which
               ;; version of straight.el to use to interpret the recipe
               ;; that must be used to clone straight.el itself. I'm
-              ;; using planets in the Solar System, for diversity (and
+              ;; using the Greek alphabet, for diversity (and
               ;; because using consecutive integers would make it
               ;; confusing when somebody else made a fork of the
               ;; project and needed to fork the version sequence as
@@ -5273,7 +5273,7 @@ according to the value of `straight-profiles'."
               ;;
               ;; The version keyword comes after the versions alist so
               ;; that you can ignore it if you don't need it.
-              "(%s)\n:pluto\n"
+              "(%s)\n:alpha\n"
               (mapconcat
                (apply-partially #'format "%S")
                versions-alist

--- a/straight.el
+++ b/straight.el
@@ -479,6 +479,10 @@ The warning message is obtained by passing MESSAGE and ARGS to
 
 ;;;;; Paths
 
+(defcustom straight-base-dir user-emacs-directory
+  "Parent path of straight directory. Defaults to `user-emacs-directory'."
+  :type 'string)
+
 (defvar straight--this-file
   (file-truename (or load-file-name buffer-file-name))
   "Absolute real path to this file, straight.el.")
@@ -496,7 +500,7 @@ SEGMENTS, return the `user-emacs-directory' itself.
 
 \(straight--dir \"straight\" \"build\" \"esup\")
 => \"~/.emacs.d/straight/build/esup/\""
-  (let ((dir user-emacs-directory))
+  (let ((dir straight-base-dir))
     (while segments
       (setq dir (expand-file-name
                  (file-name-as-directory (car segments)) dir))


### PR DESCRIPTION
This is a simple implementation of a configurable base path based on #300. 
There's a couple other changes/hacks that I've mentioned in comments.

This should not break existing installations as there are no changes to `bootstrap.el`.

Related to #274.