### PR TITLE
Generate dir file for pre generated info files

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4131,7 +4131,8 @@ repository."
                         (straight--repos-dir local-repo)
                         (straight--build-dir package)
                         flavor))
-          (when (string-match-p ".texi\\(nfo\\)?$" repo-file)
+          (when (or (string-match-p ".info$" repo-file)
+                    (string-match-p ".texi\\(nfo\\)?$" repo-file))
             (let ((texi repo-file)
                   (info
                    (concat (file-name-sans-extension build-file) ".info")))

--- a/straight.el
+++ b/straight.el
@@ -4132,8 +4132,7 @@ repository."
                         (straight--build-dir package)
                         flavor))
           (cond
-           ((string-match-p ".info$" repo-file)
-            ;; info file has already been symlinked so no more action needed.
+           ((string-match-p ".info$" build-file)
             (push build-file infos))
            ((string-match-p ".texi\\(nfo\\)?$" repo-file)
             (let ((texi repo-file)

--- a/straight.el
+++ b/straight.el
@@ -4131,15 +4131,18 @@ repository."
                         (straight--repos-dir local-repo)
                         (straight--build-dir package)
                         flavor))
-          (when (or (string-match-p ".info$" repo-file)
-                    (string-match-p ".texi\\(nfo\\)?$" repo-file))
+          (cond
+           ((string-match-p ".info$" repo-file)
+            ;; info file has already been symlinked so no more action needed.
+            (push build-file infos))
+           ((string-match-p ".texi\\(nfo\\)?$" repo-file)
             (let ((texi repo-file)
                   (info
                    (concat (file-name-sans-extension build-file) ".info")))
               (push info infos)
               (unless (file-exists-p info)
                 (let ((default-directory (file-name-directory texi)))
-                  (straight--call "makeinfo" texi "-o" info))))))
+                  (straight--call "makeinfo" texi "-o" info)))))))
         (let ((dir (straight--build-file package "dir")))
           (unless (file-exists-p dir)
             (dolist (info infos)

--- a/straight.el
+++ b/straight.el
@@ -4132,9 +4132,9 @@ repository."
                         (straight--build-dir package)
                         flavor))
           (cond
-           ((string-match-p ".info$" build-file)
+           ((string-match-p "\\.info$" build-file)
             (push build-file infos))
-           ((string-match-p ".texi\\(nfo\\)?$" repo-file)
+           ((string-match-p "\\.texi\\(nfo\\)?$" repo-file)
             (let ((texi repo-file)
                   (info
                    (concat (file-name-sans-extension build-file) ".info")))


### PR DESCRIPTION
This was only done for info files generated from texinfo files but
some packages provide pre generated info files. This makes sure the
latter are added into the main info directory menu.