### PR TITLE
Allow recipes to inherit from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,24 @@ will be looked up by default (see the section on [recipe
 lookup][#user/lookup]). You can see the default recipe for a package
 by invoking [`M-x straight-get-recipe`][#user/interactive].
 
+If `straight-allow-recipe-inheritance` is non-nil, then you only need
+to specify the components of the recpie that you want to override. All
+other components will still be looked up in the default recipe. In the
+example above, we are only interested in changing the `:fork`
+component. Therefore if `straight-allow-recipe-inheritance` is set,
+the recipe could be simplifed as follows:
+
+    (straight-use-package
+     '(el-patch :fork (:repo "your-name/el-patch")))
+
+or even simpler:
+
+    (straight-use-package
+     '(el-patch :fork "your-name/el-patch"))
+
+The `:files` keyword and all version control keywords support
+inheritance.
+
 To learn more, see the section on [the recipe format][#user/recipes].
 
 #### Additional arguments to `straight-use-package`


### PR DESCRIPTION
`:host`, `:repo`, and `:files` are inherited from the default recipe. Also `:fork` will inherit its host from the upstream recipe. These can be overridden like any recipe component.

closes #116 

For example, we can do the following simplification
### example 1
before:
```lisp
(package :host gitlab :repo "other-user/repo" 
         :files ("lisp.el")
         :fork (:host :gitlab :repo "my-user/repo"))
```
after:
```lisp
(package :fork "my-user/repo")
```
or 
```lisp
(package :fork (:repo "my-user/repo"))
```
### example 2
before:
```lisp
(package :host gitlab :repo "user/repo" :local-repo "local")
```

after:
```lisp
(package :local-repo "local")
```


Let me know what you think. If you give the green light I will add some documentation to the main README. 
