### PR TITLE
Custom build directory

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -526,11 +526,13 @@ The warning message is obtained by passing MESSAGE and ARGS to
 ;;;;; Paths
 
 (defcustom straight-base-dir user-emacs-directory
-  "Parent path of straight directory. Defaults to `user-emacs-directory'."
+  "Directory in which the straight/ subdirectory is created.
+Defaults to `user-emacs-directory'."
   :type 'string)
 
-(defcustom straight-build-subdirectory "build"
-  "Name of the subdirectory used for compiled packages.
+(defcustom straight-build-dir "build"
+  "Name of the directory into which packages are built.
+Relative to the straight/ subdirectory of `straight-base-dir'.
 Defaults to \"build\"."
   :type 'string)
 
@@ -583,12 +585,12 @@ SEGMENTS are passed to `straight--emacs-file'."
   "Get a subdirectory of the straight/build/ directory.
 SEGMENTS are passed to `straight--dir'. With no SEGMENTS, return
 the straight/build/ directory itself."
-  (apply #'straight--dir straight-build-subdirectory segments))
+  (apply #'straight--dir straight-build-dir segments))
 
 (defun straight--build-file (&rest segments)
   "Get a file in the straight/build/ directory.
 SEGMENTS are passed to `straight--file'."
-  (apply #'straight--file straight-build-subdirectory segments))
+  (apply #'straight--file straight-build-dir segments))
 
 (defun straight--autoloads-file (package)
   "Get the filename of the autoloads file for PACKAGE.

--- a/straight.el
+++ b/straight.el
@@ -529,6 +529,11 @@ The warning message is obtained by passing MESSAGE and ARGS to
   "Parent path of straight directory. Defaults to `user-emacs-directory'."
   :type 'string)
 
+(defcustom straight-build-subdirectory "build"
+  "Name of the subdirectory used for compiled packages.
+Defaults to \"build\"."
+  :type 'string)
+
 (defvar straight--this-file
   (file-truename (or load-file-name buffer-file-name))
   "Absolute real path to this file, straight.el.")
@@ -578,12 +583,12 @@ SEGMENTS are passed to `straight--emacs-file'."
   "Get a subdirectory of the straight/build/ directory.
 SEGMENTS are passed to `straight--dir'. With no SEGMENTS, return
 the straight/build/ directory itself."
-  (apply #'straight--dir "build" segments))
+  (apply #'straight--dir straight-build-subdirectory segments))
 
 (defun straight--build-file (&rest segments)
   "Get a file in the straight/build/ directory.
 SEGMENTS are passed to `straight--file'."
-  (apply #'straight--file "build" segments))
+  (apply #'straight--file straight-build-subdirectory segments))
 
 (defun straight--autoloads-file (package)
   "Get the filename of the autoloads file for PACKAGE.
@@ -4070,16 +4075,16 @@ this run of straight.el)."
                (with-temp-buffer
                  ;; Bypass `find-file-hook'.
                  (insert-file-contents-literally
-                  (straight--file
-                   "build" package
+                  (straight--build-file
+                   package
                    (format "%s-pkg.el" package)))
                  (straight--process-dependencies
                   (eval (nth 4 (read (current-buffer)))))))
              (ignore-errors
                (with-temp-buffer
                  (insert-file-contents-literally
-                  (straight--file
-                   "build" package
+                  (straight--build-file
+                   package
                    (format "%s.el" package)))
                  ;; Who cares if the rest of the header is
                  ;; well-formed? Maybe package.el does, but all we


### PR DESCRIPTION
Hello,

I use the same `.emacs.d` across different operating systems and emacs versions. With package.el, I was using customized elpa directories (like e.g. `elpa-windows-26.3`) to avoid conflicts, essentially downloading and compiling the packages as many times as I had environments.

With `straight` so far, I could get a satisfactory result using a custom directory of the form `straight-windows-26.3` in which `straight` itself was placed.

However, I came to realize that with the way `straight` separates repositories and builds, it could be made more efficient by just separating the `build` subfolders, not the whole `straight` folder. 

For example, if I want to apply modifications to a package, I would need to do it only once, not once per environment. And it would allow (I guess, I didn't test it) bootstrapping the configuration on a new environment, even without a good internet connection to download the packages. 

However, unlike `straight-base-dir`, there isn't a variable customizing where the builds go, so it requires changing a few functions after bootstrapping, recompiling `straight` in the new build directory, and reloading the new functions.

The proposed patch aims at making the process more straightforward. It adds a variable `straight-build-subdirectory` which is used instead of `"build"` in the two functions `straight--build-dir` and `straight--build-file`, and patches `straight--compute-dependencies` to use those functions instead of a hard-coded path (I believe that was a minor bug regardless).

Thanks!
