### PR TITLE
Fix issue with CRLF line endings

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2775,9 +2775,9 @@ Emacsmirror, return a MELPA-style recipe; otherwise return nil."
                             'fixedcase 'literal))))
       (dolist (org '("mirror" "attic"))
         (with-temp-buffer
-          (insert-file-contents-literally org)
+          (insert-file-contents org)
           (when (re-search-forward
-                 (format "^%S\r?$" mirror-package) nil 'noerror)
+                 (format "^%S$" mirror-package) nil 'noerror)
             (cl-return
              `(,package :type git :host github
                         :repo ,(format "emacs%s/%S" org mirror-package)))))))))
@@ -2787,7 +2787,7 @@ Emacsmirror, return a MELPA-style recipe; otherwise return nil."
   (let ((packages nil))
     (dolist (org '("mirror" "attic"))
       (with-temp-buffer
-        (insert-file-contents-literally org)
+        (insert-file-contents org)
         (setq packages (nconc (mapcar
                                (lambda (package)
                                  (replace-regexp-in-string


### PR DESCRIPTION
`insert-file-contents-literally` prevents Emacs from doing automatic line ending detection and assumes that all line endings are `\n`. This is not true for non-unix encodings such as windows (CRLF).

One way to fix this issue is try and make all the line ending regex more verbose to deal with carriage returns. This is how this was handled in #416. However I believe that the correct solution is to let Emacs automatically handle the line endings (which it is design to do). This avoids edge cases and extra complexity in the code.

The way this issue this was manifest for me was that straight was leaving the carriage returns (`^M`) on the packages names when I went to pull new packages. As you can imagine that was obviously leading to issues where the names were invalid.

<!-- Please create pull requests against the develop branch only! -->
