### PR TITLE
Support native compilation of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ chat][gitter-badge]][gitter]
         * [`check-on-save`](#check-on-save)
         * [`watch-files`](#watch-files)
     + [Customizing how packages are built](#customizing-how-packages-are-built)
+        * [Autoload generation](#autoload-generation)
+        * [Byte compilation](#byte-compilation)
+        * [Native compilation](#native-compilation)
+        * [Symbolic links](#symbolic-links)
     + [Customizing how packages are made available](#customizing-how-packages-are-made-available)
     + [Hooks run by `straight-use-package`](#hooks-run-by-straight-use-package)
   * [The recipe format](#the-recipe-format)
@@ -1633,6 +1637,8 @@ which do not bundle executable Lisp code. (Make sure to use
 [`straight-use-recipes`][#user/lookup/repos] for registering recipe
 repositories.)
 
+##### Autoload generation
+
 By specifying a non-nil value for the `:no-autoloads` attribute in a
 package's recipe, you may prevent any autoloads provided by the
 package from being generated and loaded into Emacs. This is mostly
@@ -1643,6 +1649,8 @@ you *really* know what you're doing). You can also customize the
 variable `straight-disable-autoloads` to effect this change on all
 recipes which do not explicitly specify a `:no-autoloads` attribute.
 
+##### Byte compilation
+
 By specifying a non-nil value for the `:no-byte-compile` attribute in
 a package's recipe, you may inhibit byte-compilation. See [this
 issue][#357] for discussion of why this might be useful. You can also
@@ -1650,14 +1658,25 @@ customize the variable `straight-disable-byte-compilation` to effect
 this change on all recipes which do not explicitly specify a
 `:no-byte-compile` attribute.
 
+##### Native compilation
+
+Experimental support for native compilation of Emacs Lisp code is
+currently under development in the `feature/native-comp` branch of the
+official Emacs repository (see [gccemacs][gccemacs]). When running on
+this version of Emacs, `straight.el` will perform native compilation
+of packages.
+
 By specifying a non-nil value for the `:no-native-compile` attribute
 in a package's recipe, you may inhibit native compilation. You can
 also customize the variable `straight-disable-native-compilation` to
 effect this change on all recipes which do not explicitly specify a
-`:no-native-compile` attribute. Native compilation requires
-byte-compilation, so `:no-byte-compile` and
-`straight-disable-byte-compilation` also have the effect of inhibiting
-native compilation.
+`:no-native-compile` attribute.
+
+Native compilation requires byte-compilation, so `:no-byte-compile`
+and `straight-disable-byte-compilation` will also disable native
+compilation.
+
+##### Symbolic links
 
 Usually, `straight.el` uses symbolic links ("symlinks") to make
 package files available from the build directory. This happens when
@@ -2964,6 +2983,7 @@ the version lock file. This addresses issues [#58], [#66], and [#294].
 [epkg]: https://github.com/emacscollective/epkg
 [epkgs]: https://github.com/emacsmirror/epkgs
 [forge]: https://github.com/magit/forge
+[gccemacs]: http://akrl.sdf.org/gccemacs.html
 [git]: https://git-scm.com/
 [git-credential-cache]: https://git-scm.com/docs/git-credential-cache
 [gitter-badge]: https://badges.gitter.im/raxod502/straight.el.svg

--- a/README.md
+++ b/README.md
@@ -1650,6 +1650,15 @@ customize the variable `straight-disable-byte-compilation` to effect
 this change on all recipes which do not explicitly specify a
 `:no-byte-compile` attribute.
 
+By specifying a non-nil value for the `:no-native-compile` attribute
+in a package's recipe, you may inhibit native compilation. You can
+also customize the variable `straight-disable-native-compilation` to
+effect this change on all recipes which do not explicitly specify a
+`:no-native-compile` attribute. Native compilation requires
+byte-compilation, so `:no-byte-compile` and
+`straight-disable-byte-compilation` also have the effect of inhibiting
+native compilation.
+
 Usually, `straight.el` uses symbolic links ("symlinks") to make
 package files available from the build directory. This happens when
 `straight-use-symlinks` is non-nil, the default. On Microsoft Windows,

--- a/straight.el
+++ b/straight.el
@@ -4284,7 +4284,7 @@ repository."
             (message-log-max nil))
         (native-compile-async
          (straight--build-dir package)
-         'recursively)))
+         'recursively 'late)))
     (straight--wait-for-async-jobs)))
 
 (defun straight--pending-async-jobs ()

--- a/straight.el
+++ b/straight.el
@@ -4288,8 +4288,7 @@ repository."
     (straight--wait-for-async-jobs)))
 
 (defun straight--pending-async-jobs ()
-  "How many async compilation jobs are queued or in-progress.
-Returns nil if there are no pending jobs."
+  "How many async compilation jobs are queued or in-progress."
   (if (and (boundp 'comp-files-queue)
            (fboundp 'comp-async-runnings))
       (+ (length comp-files-queue)

--- a/straight.el
+++ b/straight.el
@@ -4257,7 +4257,7 @@ repository."
          (straight--build-dir package)
          0 'force)))))
 
-;;;;; Native-compilation
+;;;;; Native compilation
 
 (defcustom straight-disable-native-compilation nil
   "Non-nil means do not `native-compile' packages by default.
@@ -4290,12 +4290,11 @@ repository."
 (defun straight--pending-async-jobs ()
   "How many async compilation jobs are queued or in-progress.
 Returns nil if there are no pending jobs."
-  (when (and (boundp 'comp-files-queue)
-             (fboundp 'comp-async-runnings))
-    (let ((pending (+ (length comp-files-queue)
-                      (comp-async-runnings))))
-      (unless (zerop pending)
-        pending))))
+  (if (and (boundp 'comp-files-queue)
+           (fboundp 'comp-async-runnings))
+      (+ (length comp-files-queue)
+         (comp-async-runnings))
+    0))
 
 (defvar straight--wait-for-async-jobs t
   "Whether to block until all async compilation jobs have completed.")


### PR DESCRIPTION
This adds support for native compilation (aka. "gccemacs"), where
byte-compiled elisp is compiled to native code. Modules will be native
compiled when they are byte-compiled, unless `:no-native-compile` or
`straight-disable-native-compilation` are set.

Has no effect on emacs versions without the `native-compile` function.

Possibly addresses #492.