### PR TITLE
Don't block for native compilation

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4289,10 +4289,12 @@ individual package recipe."
                                  straight-disable-native-compilation))))
 
 (defun straight--native-compile-package (recipe)
-  "Native-compile files for the symlinked package specified by RECIPE.
+  "Queue native compilation for the symlinked package specified by RECIPE.
 RECIPE should be a straight.el-style plist. Note that this
 function only modifies the build folder, not the original
-repository."
+repository. Also note that native compilation occurs
+asynchronously, and will continue in the background after
+`straight-use-package' returns."
   (when (and (fboundp 'native-compile-async)
              (straight--native-compile-package-p recipe))
     (straight--with-plist recipe
@@ -4301,29 +4303,7 @@ repository."
             (message-log-max nil))
         (native-compile-async
          (straight--build-dir package)
-         'recursively 'late)))
-    (straight--wait-for-async-jobs)))
-
-(defun straight--pending-async-jobs ()
-  "How many async compilation jobs are queued or in-progress."
-  (if (and (boundp 'comp-files-queue)
-           (fboundp 'comp-async-runnings))
-      (+ (length comp-files-queue)
-         (comp-async-runnings))
-    0))
-
-(defvar straight--wait-for-async-jobs t
-  "Whether to block until all async compilation jobs have completed.")
-
-(defun straight--wait-for-async-jobs ()
-  "Block until all async compilation jobs have completed (maybe).
-Blocking can be suppressed by setting `straight--wait-for-async-jobs' to nil."
-  (when (and (fboundp 'comp-async-runnings)
-             straight--wait-for-async-jobs)
-    (let ((inhibit-message t)
-          (message-log-max nil))
-      (while (not (zerop (comp-async-runnings)))
-        (sleep-for 0.1)))))
+         'recursively 'late)))))
 
 ;;;;; Info compilation
 


### PR DESCRIPTION
Blocking until native compilation has completed is not necessary or
desirable for standard usage of `straight.el`, so has been removed.

This has the added benefit of reducing our exposure to the API of
`comp.el` while it's under active development.

Related to #511 
Related to #507