### PR TITLE
straight-x.el: update lockfile version

### DIFF
--- a/straight-x.el
+++ b/straight-x.el
@@ -153,7 +153,7 @@
   (let ((lockfile-path (straight--versions-lockfile 'pinned)))
     (with-temp-file lockfile-path
       (insert
-       (format "(%s)\n:alpha\n"
+       (format "(%s)\n:beta\n"
                (mapconcat
                 (apply-partially #'format "%S")
                 straight-x-pinned-packages


### PR DESCRIPTION
`straight-x.el` was not changed in https://github.com/raxod502/straight.el/commit/3037bb3ed1b905f18d2d6bee904d6a6a6e89b2a3 and still contains the old lockfile version.