### PR TITLE
Set load-in-progress to t when processing autoloads

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4580,7 +4580,8 @@ RECIPE is a straight.el-style plist."
                        straight--autoloads-cache)))
           ;; Some autoloads files expect to be loaded normally, rather
           ;; than read and evaluated separately. Fool them.
-          (let ((load-file-name (straight--autoloads-file package)))
+          (let ((load-file-name (straight--autoloads-file package))
+                (load-in-progress t))
             ;; car is the feature list, cdr is the autoloads.
             (dolist (form (cdr (gethash package straight--autoloads-cache)))
               (eval form))))


### PR DESCRIPTION
Several packages (e.g. realgud [1]) expect `load-in-progress` variable
to be set to `t` when their autoloads are evaluated, but `straight`
fails to do so in `straight--activate-package-autoloads`, thus
breaking build of such packages. This patch addresses the issue by
explicitly setting `load-in-progress` to `t` in
`straight--activate-package-autoloads`.

[1] https://github.com/realgud/realgud/blob/24c02f07c4ae6610278da1f04a2479dc3d9b6bdf/realgud.el#L179