### PR TITLE
Add el-get recipe support

### DIFF
--- a/bootstrap.el
+++ b/bootstrap.el
@@ -99,6 +99,10 @@
                                    :local-repo "elpa"
                                    :no-build t)))
 
+(straight-use-recipes '(el-get :type git :host github
+                               :repo "dimitri/el-get"
+                               :no-build t))
+
 (if straight-recipes-emacsmirror-use-mirror
     (straight-use-recipes
      '(emacsmirror-mirror :type git :host github


### PR DESCRIPTION
Builds off #535 to add support for el-get recipes.
Closes: #115 
Related: #72

# Caveats:

- only lists/retrieves recipes of `:type` `git` and `github`

This accounts for roughly 76% of el-get's packages. (1373 out of 1793)

- does not implement el-get's `:prepare` or `:post-init` behavior.

We breifly discussed this in #535, but I have some concerns about implementing it.
I'm not sure how to do this in a way that doesn't stomp `use-package` declarations and I think that sort of behavior is best left to `use-package` or similar solutions.
One idea I had was to simple report whether or not a package has a `:prepare` and/or `:post-init` value when installing the package. This way the user can add those commands to their init via their preferred method if they so choose.

- dependency management

I see that `straight--compute-dependencies` handles pkg.el files and the `Package-Requires:` header keyword of .el files.
el-get also has the notion of an explicit `:depends` keyword that maps to an alleged list (I have seen some that do not match their stated dependencies in the `Packages-Requires` header) of the package's dependencies.
Not sure if it would be worth it or not to use this information.

Still a work in progress, but I figured we could get a conversation started on the implementation and try some ideas out. 



