### PR TITLE
Fix/smoke test

### DIFF
--- a/scripts/smoke-test.bash
+++ b/scripts/smoke-test.bash
@@ -9,4 +9,4 @@ ln -sf "$PWD" "$HOME/.emacs.d/straight/repos/straight.el"
 # We need to test with a package that supports Emacs 24.5 here.
 emacs --batch -l "$HOME/.emacs.d/straight/repos/straight.el/bootstrap.el" \
       --eval "(straight-use-package 'use-package)"                        \
-      --eval "(use-package company-mode :straight t)"
+      --eval "(use-package company :straight t)"


### PR DESCRIPTION
Correct erroneous reference to `company-mode` in https://github.com/raxod502/straight.el/commit/acd268e851d46beb1accb29d410d83c4eb8ef48c 