### PR TITLE
Add straight-vc-git-post-clone-hook for post-clone git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1781,7 +1781,32 @@ since otherwise this cache file may grow quite large over time.
 
 #### Hooks run by `straight-use-package`
 
-Currently, `straight-use-package` supports two hooks:
+Currently, `straight-use-package` supports three hooks:
+
+* `straight-vc-git-post-clone-hook`: The functions in this hook are
+  run just after cloning a git repository.  This allows users to
+  automate custom configuration of Elisp Git repositories after they
+  have been cloned.  For example, the `user.email` `git-config`
+  variable could be set on clone, to make upstream contributions more
+  convenient for developers who use different email addresses for
+  different repositories.
+
+  Each hook function is passed the following [keyword arguments]:
+
+    - `:repo-dir` - the local directory to which the repository was
+      cloned
+    - `:remote` - the name of the remote from which the repository was
+      cloned
+    - `:url` - the URL from which the repository was cloned
+    - `:branch` - the branch as specified by the recipe, if any,
+      otherwise `nil`
+    - `:depth` - the clone depth as specified by the recipe or
+      `straight-vc-git-default-clone-depth`
+    - `:commit` - the specific commit which was requested via the
+      lockfile, if any, otherwise `nil`
+
+  Since keyword arguments are used, each function should be defined
+  via `cl-defun`, and `&key` used at the front of the argument list.
 
 * `straight-use-package-prepare-functions`: The functions in this hook
   are run just before a package would be built, even if the package
@@ -3437,6 +3462,7 @@ savings on network bandwidth and disk space.
 [hydra-wiki-straight-entry]: https://github.com/abo-abo/hydra/wiki/straight.el
 [hydra]: https://github.com/abo-abo/hydra
 [issues]: https://github.com/raxod502/straight.el/issues
+[keyword arguments]: https://www.emacswiki.org/emacs/KeywordArguments
 [magit]: https://magit.vc/
 [markdown-toc]: https://github.com/jonschlinkert/markdown-toc
 [melpa-recipe-format]: https://github.com/melpa/melpa#recipe-format


### PR DESCRIPTION
Add a hook so that users can automate custom configuration of elisp git repositories after they have been cloned.  For example, the `user.email` git config variable could be set on clone, to make upstream contributions more convenient for developers who use different email addresses for different repositories.

See https://github.com/aspiers/emacs/blob/3b2ec1b027065d360880984186ccd1ae419ecd4e/.emacs.d/init.d/as-package-loading.el#L133-L143 for an example.

----

# 

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->