### PR TITLE
Add no-native-compile packages to deferred-compilation-black-list

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -113,6 +113,9 @@ They are still logged to the *Messages* buffer.")))
 
 ;;;; Functions from other packages
 
+;; `comp'
+(defvar comp-deferred-compilation-black-list)
+
 ;; `finder-inf'
 (defvar package--builtins)
 
@@ -140,9 +143,6 @@ They are still logged to the *Messages* buffer.")))
 (declare-function use-package-normalize/:ensure "use-package")
 (declare-function use-package-only-one "use-package")
 (declare-function use-package-process-keywords "use-package")
-
-;; `comp'
-(defvar comp-deferred-compilation-black-list)
 
 ;;;; Customization variables
 


### PR DESCRIPTION
Deferred compilation automatically compiles any `.elc` that is loaded, and is now enabled by default on native-comp builds of Emacs.  This patch makes the `:no-native-compile` keyword behave as expected by blacklisting the package from deferred compilation.