### PR TITLE
Add straight-bug-report, straight-version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,16 @@ assignees: ''
 ## Directions to reproduce
 
 <!--
-Please give instructions for how to reproduce the behavior _starting from an empty `~/.emacs.d`_. Unfortunately, I simply don't have enough time to check out your bug report unless it has clear instructions for this. To do this, start with an empty `~/.emacs.d/init.el`, add the bootstrap snippet, and then add any additional code from your init-file that's needed to set up the buggy behavior. Then include a list of steps to follow (commands to run, files to modify, whatever) after Emacs startup.
+Please give instructions for how to reproduce the behavior _starting from an empty `~/.emacs.d`_.
+Unfortunately, I simply don't have enough time to check out your bug report unless it has clear instructions for this.
+straight.el provides a macro, `straight-bug-report`, which can be used to easily create a minimal reproduction case in a clean Emacs environment.
+Please use this if possible. For instructions, see:
+
+https://github.com/raxod502/straight.el#debugging
+
+and the `straight-bug-report` docstring.
+
+If `straight-bug-report` is not available or fails you can still create a reproduction case manually. To do this, start with an empty `~/.emacs.d/init.el`, add the bootstrap snippet, and then add any additional code from your init-file that's needed to set up the buggy behavior. Then include a list of steps to follow (commands to run, files to modify, whatever) after Emacs startup.
 
 Make sure you're using the latest version of straight.el. You can do this by including (setq straight-repository-branch "develop") in your init-file before the bootstrap snippet.
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,58 @@ reason to, and it might result in oddities like packages getting
 loaded more than once.
 
 #### Debugging
+* straight.el provides a macro, `straight-bug-report`, to test
+  straight.el in a clean environment. If possible, please use this
+  when creating bug reports.
+
+  `straight-bug-report` accepts the following keyword value pairs:
+
+  - `:pre-bootstrap (Form)...`
+      Forms evaluated before bootstrapping straight.el
+      e.g.
+
+        (setq straight-repository-branch \"develop\")
+
+      Note this example is already in the default bootstrapping code.
+
+  - `:post-bootstrap (Form)...`
+      Forms evaluated in the testing environment after boostrapping.
+      e.g.
+
+        (straight-use-package '(example :type git :host github))
+
+  - `:interactive Boolean`
+      If nil, the subprocess will immediately exit after the test.
+      Output will be printed to `straight-bug-report--process-buffer`
+      Otherwise, the subprocess will be interactive.
+
+  - `:preserve Boolean`
+      If t, the test directory is left in the directory stored in the
+      variable `temporary-file-directory'. Otherwise, it is
+      immediately removed after the test is run.
+
+  - `:executable String`
+      Indicate the Emacs executable to launch. Defaults to `"emacs"`.
+
+  - `:raw Boolean`
+      If t, the raw process output is sent to
+      `straight-bug-report--process-buffer`. Otherwise, it is
+      formatted as markdown for submitting as an issue."
+
+   For example:
+
+        (straight-bug-report
+          :pre-bootstrap
+          (message "before bootstrap")
+          (message "multiple forms allowed")
+          :post-bootstrap
+          (message "after bootstrap")
+          (message "multiple forms allowed")
+          (straight-use-package '(my-broken-package))
+          (message "bye"))
+
+  The above will run your test in a clean environment and produce a
+  buffer with information you can paste directly into the issue body.
 
 * Sometimes, in a corporate environment, `url-retrieve-synchronously`
   may not work and `straight.el` will be unable to download the


### PR DESCRIPTION
straight-bug-report: macro that allows declaring reproducible bug
reports. Test code is run in a clean Emacs environment. Output is
formatted to be easily shared.

straight-version: return straight.el version info

See: #471

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
