### PR TITLE
Add straight-pull-recipe-repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2103,10 +2103,12 @@ As mentioned in the [conceptual overview][#concepts/lookup], recipe
 repositories are just regular packages, with some extra code to look
 up recipes in the relevant local repository.
 
-This means that updating a recipe repository is done the same way as
+This means that updating a recipe repository may be done the same way as
 updating a regular package, i.e. with [`M-x
-straight-pull-package`][#user/interactive/vc]. You should do this if
-you find that a package isn't listed by `M-x
+straight-pull-package`][#user/interactive/vc].
+A convenience command with interactive completion for recipe repositories,
+`straight-pull-recipe-repositories`, is provided as well.
+You should use one of these if you find that a package isn't listed by `M-x
 straight-use-package`—perhaps it was added recently.
 
 Note that there is currently some potentially surprising behavior if

--- a/straight.el
+++ b/straight.el
@@ -4807,12 +4807,36 @@ action, just return it)."
            ;; any messages.
            (recipe (straight-recipes-retrieve package sources)))
       (unless recipe
-        (user-error "Recipe for %S is malformed" package))
+        (user-error
+         (concat "Recipe for \"%S\" malformed or missing. "
+                 "Updating recipe repositories: %s "
+                 "with straight-pull-recipe-repositories may fix this.")
+         package sources))
       (pcase action
         (`insert (insert (format "%S" recipe)))
         (`copy (kill-new (format "%S" recipe))
                (straight--output "Copied \"%S\" to kill ring" recipe))
         (_ recipe)))))
+
+;;;;; Update recipe repositories
+(defun straight-pull-recipe-repositories (&optional sources)
+  "Update recipe repository SOURCES.
+When called with `\\[universal-argument]', prompt for SOURCES.
+If SOURCES is nil, update sources in `straight-recipe-repositories'."
+  (interactive (list (if (equal current-prefix-arg '(4))
+                         (completing-read-multiple
+                          "Recipe Repositories (empty to select all): "
+                          straight-recipe-repositories nil 'require-match)
+                       straight-recipe-repositories)))
+  (dolist (source (delete-dups
+                   (mapcar (lambda (src) (if (stringp src) (intern src) src))
+                           (or sources straight-recipe-repositories))))
+    (unless (member source straight-recipe-repositories)
+      (user-error
+       (concat "Unregistered recipe repository: \"%S\". "
+               "Register recipe source with straight-use-recipes")
+       source))
+    (straight-pull-package-and-deps (symbol-name source) 'upstream)))
 
 ;;;;; Jump to package website
 


### PR DESCRIPTION
Convenience command to update registered recipe repositories.
Adds better error message for missing recipe case in
straight-get-recipe.

See: #397

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
