### PR TITLE
shallow clone limits fetch refspec to single branch

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2190,7 +2190,7 @@ clone of everything."
            "--no-checkout" url repo-dir
            "--depth" (number-to-string depth)
            "--branch" branch
-           "--single-branch"
+           "--no-single-branch"
            "--no-tags"))
       ;; Fallback for dumb http protocol.
       (error


### PR DESCRIPTION
When `straight-vc-git-default-clone-depth` is set to an integer, the presence of the `--depth` option to `git clone` results in a `fetch` refspec which is limited to the branch fetched:

    remote.origin.fetch=+refs/heads/master:refs/remotes/origin/master

(Incidentally, `git clone` does this even without the `--single-branch` option which `straight.el` passes in this case.)

The (minor) problem with this is that if the user of `straight.el` wants to contribute development of that package, and the package has a workflow which involves other branches (e.g. Orgmode incorporates the latest changes onto a `maint` branch), then a straight git fetch origin (or equivalent via magit or some other UI) will not fetch any other branches.

Arguably this is working as intended, but it does violate the Principle of Least Surprise - or at least it feels that way to me since it caused me more than a few minutes of head-scratching, and as a former contributor to git I'm not exactly a git newbie.

I've found what seems to be a reasonable solution to this: simply change `--single-branch` to `--no-single-branch`. This will make all upstream branches available, but the clone depth is still respected so it's usually not a significantly larger download.

For example, try:

    git clone --depth 1 --no-single-branch --no-tags --branch master https://code.orgmode.org/bzg/org-mode.git

and you will see that it fetches one commit only per branch, and that the refspec is set up nicely for fetching of all branches in the future:

    remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*

## Directions to reproduce

Set `straight-vc-git-default-clone-depth` to `1` and then clone any package via `straight.el` as normal.