### PR TITLE
Fix: straight-bug-report: add missing format spec to message

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6216,7 +6216,7 @@ Interactively, or when MESSAGE is non-nil, show in the echo area."
           (eval-print-last-sexp)))
       (load bootstrap-file nil 'nomessage))
     (condition-case nil
-        (message "Test run with version: " (straight-version))
+        (message "Test run with version: %s" (straight-version))
       (error nil)))
   "Static bootstrap portion of bug report metaprogram.")
 


### PR DESCRIPTION
Call to `message` was missing a formatting spec, so output of `straight-version` in testing environment was not being printed.

