### PR TITLE
Ignore text properties in straight--process-get-output

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -952,8 +952,9 @@ This is nil if the process could not be run, or if
   (with-current-buffer (straight--process-get-buffer)
     (when (and straight--process-output-beginning
                straight--process-output-end)
-      (buffer-substring straight--process-output-beginning
-                        straight--process-output-end))))
+      (buffer-substring-no-properties
+       straight--process-output-beginning
+       straight--process-output-end))))
 
 (defun straight--call (program &rest args)
   "Run executable PROGRAM with given ARGS.


### PR DESCRIPTION
`straight--process-get-output` uses `buffer-substring` to copy the
output of a process, which means that the text properties are copied
too. Most of the time, this is fine, as there are no text properties.

However, when using the [`ws-butler`] package, the `ws-butler-chg`
text property is present and copied. This means that, for example,
`straight-freeze-versions` produces a `default.el` file looking like
this:

```emacs-lisp
(("alert" . #("7046393272686c7a1a9b3e7f7b1d825d2e5250a6" 0 40 (ws-butler-chg chg)))
 ("anchored-transpose" . #("43b37bbc5dc0fe4b7b1b46c5e1d98553e9b527ae" 0 40 (ws-butler-chg chg)))
 ..)
```

while it should be:

```emacs-lisp
(("alert" . "7046393272686c7a1a9b3e7f7b1d825d2e5250a6")
 ("anchored-transpose" . "43b37bbc5dc0fe4b7b1b46c5e1d98553e9b527ae")
 ..)
```

Fix this by using `buffer-substring-no-properties` instead of
`buffer-substring`.

[`ws-butler`]: https://github.com/lewang/ws-butler

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
