### PR TITLE
Allow specifying protocol in package recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2087,10 +2087,9 @@ These are the keywords meaningful for the `git` backend:
   then the repository is cloned with the option `--depth N`. This
   works even when a commit is specified (e.g. by version lockfiles).
   The default value is `full`.
-* `:protocol`: If non-nil, specify the default protocol to be used
-  when interacting with the remote repository. Takes the same values
-  as `straight-vc-git-default-protocol`. This keyword should probably
-  only be used when overriding a recipe locally.
+* `:protocol`: If non-nil, force this protocol to be used when
+  interacting with the remote repository. Takes the same values as
+  `straight-vc-git-default-protocol`.
 
 This section tells you how the `git` backend, specifically, implements
 the version-control backend API:

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ set of additional directives. For example, the `git` backend accepts:
 * `:branch`
 * `:nonrecursive`
 * `:fork`
+* `:protocol`
 
 If a local repository is not present, then its fetch recipe describes
 how to obtain it. This is done using the `straight-vc-clone` function,
@@ -2086,6 +2087,10 @@ These are the keywords meaningful for the `git` backend:
   then the repository is cloned with the option `--depth N`. This
   works even when a commit is specified (e.g. by version lockfiles).
   The default value is `full`.
+* `:protocol`: If non-nil, specify the default protocol to be used
+  when interacting with the remote repository. Takes the same values
+  as `straight-vc-git-default-protocol`. This keyword should probably
+  only be used when overriding a recipe locally.
 
 This section tells you how the `git` backend, specifically, implements
 the version-control backend API:

--- a/straight.el
+++ b/straight.el
@@ -1974,19 +1974,19 @@ The URLs do not necessarily need to match exactly; they just have
 to satisfy `straight-vc-git--urls-compatible-p'."
   (straight-vc-git--destructure recipe
       (local-repo upstream-repo upstream-host upstream-remote
-                  fork-repo fork-host fork-remote)
+                  fork-repo fork-host fork-remote protocol)
     (and (or (null upstream-repo)
              (straight-vc-git--ensure-remote
               local-repo
               upstream-remote
               (straight-vc-git--encode-url
-               upstream-repo upstream-host)))
+               upstream-repo upstream-host protocol)))
          (or (null fork-repo)
              (straight-vc-git--ensure-remote
               local-repo
               fork-remote
               (straight-vc-git--encode-url
-               fork-repo fork-host))))))
+               fork-repo fork-host protocol))))))
 
 ;; The following handles only merges, not rebases. See
 ;; https://github.com/raxod502/straight.el/issues/271.
@@ -2321,12 +2321,12 @@ out, signal a warning. If COMMIT is nil, check out the branch
 specified in RECIPE instead. If that fails, signal a warning."
   (straight-vc-git--destructure recipe
       (package local-repo branch remote upstream-repo upstream-host
-               upstream-remote fork-repo repo host nonrecursive depth)
+               upstream-remote fork-repo repo host protocol nonrecursive depth)
     (unless upstream-repo
       (error "No `:repo' specified for package `%s'" package))
     (let ((success nil)
           (repo-dir (straight--repos-dir local-repo))
-          (url (straight-vc-git--encode-url repo host))
+          (url (straight-vc-git--encode-url repo host protocol))
           (depth (or depth straight-vc-git-default-clone-depth)))
       (unwind-protect
           (progn
@@ -2340,7 +2340,7 @@ specified in RECIPE instead. If that fails, signal a warning."
                   (default-directory repo-dir))
               (when fork-repo
                 (let ((url (straight-vc-git--encode-url
-                            upstream-repo upstream-host)))
+                            upstream-repo upstream-host protocol)))
                   (straight--get-call "git" "remote" "add" upstream-remote url)
                   (straight--get-call "git" "fetch" upstream-remote)))
               (when commit
@@ -2483,7 +2483,7 @@ then returned."
 
 (defun straight-vc-git-keywords ()
   "Return a list of keywords used by the VC backend for Git."
-  '(:repo :host :branch :remote :nonrecursive :upstream :fork :depth))
+  '(:repo :host :branch :remote :nonrecursive :upstream :fork :depth :protocol))
 
 ;;;; Fetching repositories
 

--- a/straight.el
+++ b/straight.el
@@ -2981,12 +2981,12 @@ Emacsmirror, return a MELPA-style recipe; otherwise return nil."
          ;; this writing, there are no Gitlab URLs (which makes
          ;; sense, since all the repositories should be hosted on
          ;; github.com/emacsmirror).
-         (cl-destructuring-bind (repo host protocol)
+         (cl-destructuring-bind (repo host _protocol)
              (straight-vc-git--decode-url url)
            (if host
                `(,package :type git :host ,host
-                          :repo ,repo :protocol ,protocol)
-             `(,package :type git :repo ,repo :protocol ,protocol))))))
+                          :repo ,repo)
+             `(,package :type git :repo ,repo))))))
 
 (defun straight-recipes-emacsmirror-list ()
   "Return a list of recipes available in Emacsmirror, as a list of strings."

--- a/straight.el
+++ b/straight.el
@@ -2483,7 +2483,8 @@ then returned."
 
 (defun straight-vc-git-keywords ()
   "Return a list of keywords used by the VC backend for Git."
-  '(:repo :host :branch :remote :nonrecursive :upstream :fork :depth :protocol))
+  '(:repo :host :branch :remote :nonrecursive
+          :upstream :fork :depth :protocol))
 
 ;;;; Fetching repositories
 


### PR DESCRIPTION
Fixes #92 

This PR allows specifying git protocol as part of a package recipe.  
I included the note about only using it for recipe overrides, because I couldn't think of another use case, correct me if I'm wrong (the only reason why I took this on is because I have all packages cloned over SSH, except for `org-drill`, which is on GitLab where I don't have an account, so I had to clone it over HTTPS).

Also, does it make sense to specify a different protocol for a fork? I haven't included this functionality because I don't use forks, but I don't think it would be hard to add it.