### PR TITLE
straight-bug-report: Improve report form formatting

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6263,16 +6263,18 @@ If PREAMBLE is non-nil, it is inserted after the instructions."
 
 (defun straight-bug-report--report-form (form)
   "Convert elisp FORM into formatted string."
-  (let ((string (mapconcat
-                 (lambda (el)
-                   (format (concat (when (and el (listp el)) "\n")
-                                   "%S"
-                                   (unless (keywordp el) "\n"))
-                           el))
-                 form " ")))
+  (let* ((last (car (last form)))
+         (string (mapconcat
+                  (lambda (el)
+                    (format (concat (when (and el (listp el)) "\n")
+                                    "%S"
+                                    (unless (or (keywordp el)
+                                                (eq last el)) "\n"))
+                            el))
+                  form " ")))
     (with-temp-buffer
       ;; Trim last newline to prevent dangling paren
-      (insert (concat "(" (string-trim string nil "\n") ")"))
+      (insert "(" string ")")
       (goto-char (point-min))
       ;; Remove empty lines
       (flush-lines "\\(?:^[[:space:]]*$\\)")


### PR DESCRIPTION
`pp` and `pp-to-string` do a fair job of pretty printing the report
form, but they do not make optimal use of vertical space and tend to
produce wide forms. Multiple KEY VAL pairs are printed on the same line.
`straight-bug-report--report-form` returns a string which makes better
use of vertical space.

Before (with `pp` or `pp-to-string`):

```emacs-lisp
(straight-bug-report :preserve t :raw nil :user-dir "pretty-print-test" :pre-bootstrap
                     (message "hi")
                     (message "two")
                     :post-bootstrap
                     (message "bye"))

```

After (with `straight-bug-report--report-form`):

```emacs-lisp
(straight-bug-report
  :preserve t
  :raw nil
  :user-dir "pretty-print-test"
  :pre-bootstrap 
  (message "hi")
  (message "two")
  :post-bootstrap 
  (message "bye"))
```

