### PR TITLE
Add unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ EMACS ?= emacs
 
 SHELL := bash
 
+#Point to path of your local emacs-buttercup install
+BUTTERCUP = ../emacs-buttercup/
+
 # The order is important for compilation.
 for_compile := straight.el bootstrap.el install.el straight-x.el	\
 	benchmark/straight-bench.el
@@ -48,7 +51,6 @@ checkdoc: ## Check docstring style
 .PHONY: longlines
 longlines: ## Check for long lines
 	@scripts/check-line-length.bash
-
 .PHONY: checkindent
 checkindent: ## Ensure that indentation is correct
 	@tmpdir="$$(mktemp -d)"; for file in $(for_checkindent); do \
@@ -94,3 +96,8 @@ bench: ## Run benchmarking script against package.el
 .PHONY: docker
 docker: ## Start a Docker shell; e.g. make docker VERSION=25.3
 	@scripts/docker.bash "$(VERSION)" "$(CMD)"
+
+.PHONY: test
+test: straight.elc
+	$(EMACS) -Q --batch -L . -L $(BUTTERCUP) \
+		-l buttercup -f buttercup-run-discover

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ checkdoc: ## Check docstring style
 .PHONY: longlines
 longlines: ## Check for long lines
 	@scripts/check-line-length.bash
+
 .PHONY: checkindent
 checkindent: ## Ensure that indentation is correct
 	@tmpdir="$$(mktemp -d)"; for file in $(for_checkindent); do \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EMACS ?= emacs
 SHELL := bash
 
 #Point to path of your local emacs-buttercup install
-BUTTERCUP = ../emacs-buttercup/
+BUTTERCUP ?= ../emacs-buttercup/
 
 # The order is important for compilation.
 for_compile := straight.el bootstrap.el install.el straight-x.el	\

--- a/tests/test-straight.el
+++ b/tests/test-straight.el
@@ -1,14 +1,5 @@
 ;;; straight.el --- Tests for straight.el -*- lexical-binding: t; -*-
-;; Package-Requires: ((buttercup))
 
-;; Created: 06 Oct 2020
-;; Version: prerelease
-
-
-;;; Commentary:
-;;
-
-;;; Code:
 (require 'buttercup)
 (require 'straight)
 
@@ -109,9 +100,3 @@
 
 
 (provide 'straight-test)
-
-;; Local Variables:
-;; End:
-
-
-;;; test-straight.el ends here

--- a/tests/test-straight.el
+++ b/tests/test-straight.el
@@ -1,0 +1,120 @@
+;;; straight.el --- Tests for straight.el -*- lexical-binding: t; -*-
+;; Package-Requires: ((buttercup))
+
+;; Created: 06 Oct 2020
+;; Version: prerelease
+
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'buttercup)
+(require 'straight)
+
+(defvar straight-test-default-recipe '( :package "package"
+                                        :host github :type git
+                                        :repo "upstream/repo"))
+(describe "straight.el"
+  (describe "straight--normalize-alist"
+    (describe "(alist)"
+      (it "does not mutate ALIST"
+        (expect (let ((alist '((a . b) (a . c))))
+                  (straight--normalize-alist '((a . b) (a . c)))
+                  alist)
+                :to-equal '((a . b) (a . c))))
+      (it "removes duplicate keys"
+        (expect (straight--normalize-alist '((a . b) (a . c)))
+                :to-equal '((a . c)))))
+    (describe "(alist test)"
+      (it "respects TEST function"
+        (expect (straight--normalize-alist '(("a" . b) ("a" . c)) #'equal)
+                :to-equal '(("a" . c))))))
+  (describe "straight--alist-set"
+    (describe "(key val alist)"
+      (it "adds (KEY . VAL) to front of ALIST"
+        (expect (straight--alist-set "a" 'b  '(("c" . d)))
+                :to-equal '(("a" . b) ("c" . d))))
+      (it "sets first KEY match cdr"
+        (expect (straight--alist-set "a" 'd  '(("a" . b) ("a" . c)))
+                :to-equal '(("a" . d) ("a" . c)))))
+    (describe "(key val alist symbol)"
+      (it "tests with eq when SYMBOL non-nil"
+        (expect (straight--alist-set "a" 'a  '((a . b) (a . c)) 'symbol)
+                :to-equal '(("a" . a) (a . b) (a . c))))))
+(describe "straight-vc-git--fork-repo"
+  (before-each (setq straight-host-usernames
+                     '((github . "githubUser")
+                       (gitlab . "gitlabUser")
+                       (bitbucket . "bitbucketUser"))))
+  (describe ":fork nil"
+    (it "returns inherited upstream :repo"
+      ;; explicit
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork nil))
+              :to-equal "upstream/repo")
+      ;; implicit
+      (expect (straight-vc-git--fork-repo straight-test-default-recipe)
+              :to-equal "upstream/repo")))
+  (describe ":fork t"
+    (it "returns \"straight-host-username/upstream-repo-name\""
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork t))
+              :to-equal "githubUser/repo")))
+  (describe ":fork string"
+    (it "returns \"STRING/upstream-repo\" with suffixed or absent \"/\""
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork "fork/"))
+              :to-equal "fork/repo")
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork "fork"))
+              :to-equal "fork/repo"))
+    (it "returns \"straight-host-username/STRING\" when prefixed with \"/\""
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork "/rename"))
+              :to-equal "githubUser/rename"))
+    (it "returns \"STRING\" when contains \"/\" that is not a prefix or suffix"
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe :fork "fork/rename"))
+              :to-equal "fork/rename")))
+  (describe ":fork plist"
+    (it "looks up :fork PLIST's :host"
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:host bitbucket)))
+              :to-equal "bitbucketUser/repo"))
+    (it "gives precedence to :fork PLIST's :repo"
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:repo "/rename")))
+              :to-equal "githubUser/rename")
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:host github :repo "user/")))
+              :to-equal "user/repo")
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:host gitlab :repo "full/override")))
+              :to-equal "full/override")
+      ;; https://github.com/raxod502/straight.el/issues/592
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:host nil :repo "/local/repo")))
+              :to-equal "/local/repo"))
+    (it "looks up the user when :fork PLIST does not provide a :repo"
+      (expect (straight-vc-git--fork-repo
+               (plist-put straight-test-default-recipe
+                          :fork '(:branch "feature")))
+              :to-equal "githubUser/repo")))))
+
+
+(provide 'straight-test)
+
+;; Local Variables:
+;; End:
+
+;;; straight-test.el ends here
+
+
+
+;;; test-straight.el ends here

--- a/tests/test-straight.el
+++ b/tests/test-straight.el
@@ -42,79 +42,76 @@
       (it "tests with eq when SYMBOL non-nil"
         (expect (straight--alist-set "a" 'a  '((a . b) (a . c)) 'symbol)
                 :to-equal '(("a" . a) (a . b) (a . c))))))
-(describe "straight-vc-git--fork-repo"
-  (before-each (setq straight-host-usernames
-                     '((github . "githubUser")
-                       (gitlab . "gitlabUser")
-                       (bitbucket . "bitbucketUser"))))
-  (describe ":fork nil"
-    (it "returns inherited upstream :repo"
-      ;; explicit
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork nil))
-              :to-equal "upstream/repo")
-      ;; implicit
-      (expect (straight-vc-git--fork-repo straight-test-default-recipe)
-              :to-equal "upstream/repo")))
-  (describe ":fork t"
-    (it "returns \"straight-host-username/upstream-repo-name\""
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork t))
-              :to-equal "githubUser/repo")))
-  (describe ":fork string"
-    (it "returns \"STRING/upstream-repo\" with suffixed or absent \"/\""
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork "fork/"))
-              :to-equal "fork/repo")
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork "fork"))
-              :to-equal "fork/repo"))
-    (it "returns \"straight-host-username/STRING\" when prefixed with \"/\""
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork "/rename"))
-              :to-equal "githubUser/rename"))
-    (it "returns \"STRING\" when contains \"/\" that is not a prefix or suffix"
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe :fork "fork/rename"))
-              :to-equal "fork/rename")))
-  (describe ":fork plist"
-    (it "looks up :fork PLIST's :host"
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:host bitbucket)))
-              :to-equal "bitbucketUser/repo"))
-    (it "gives precedence to :fork PLIST's :repo"
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:repo "/rename")))
-              :to-equal "githubUser/rename")
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:host github :repo "user/")))
-              :to-equal "user/repo")
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:host gitlab :repo "full/override")))
-              :to-equal "full/override")
-      ;; https://github.com/raxod502/straight.el/issues/592
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:host nil :repo "/local/repo")))
-              :to-equal "/local/repo"))
-    (it "looks up the user when :fork PLIST does not provide a :repo"
-      (expect (straight-vc-git--fork-repo
-               (plist-put straight-test-default-recipe
-                          :fork '(:branch "feature")))
-              :to-equal "githubUser/repo")))))
+  (describe "straight-vc-git--fork-repo"
+    (before-each (setq straight-host-usernames
+                       '((github . "githubUser")
+                         (gitlab . "gitlabUser")
+                         (bitbucket . "bitbucketUser"))))
+    (describe ":fork nil"
+      (it "returns inherited upstream :repo"
+        ;; explicit
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork nil))
+                :to-equal "upstream/repo")
+        ;; implicit
+        (expect (straight-vc-git--fork-repo straight-test-default-recipe)
+                :to-equal "upstream/repo")))
+    (describe ":fork t"
+      (it "returns \"straight-host-username/upstream-repo-name\""
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork t))
+                :to-equal "githubUser/repo")))
+    (describe ":fork string"
+      (it "returns \"STRING/upstream-repo\" with suffixed or absent \"/\""
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork "fork/"))
+                :to-equal "fork/repo")
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork "fork"))
+                :to-equal "fork/repo"))
+      (it "returns \"straight-host-username/STRING\" when prefixed with \"/\""
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork "/rename"))
+                :to-equal "githubUser/rename"))
+      (it "returns \"STRING\" when \"/\" that is not a prefix or suffix"
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe :fork "fork/rename"))
+                :to-equal "fork/rename")))
+    (describe ":fork plist"
+      (it "looks up :fork PLIST's :host"
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:host bitbucket)))
+                :to-equal "bitbucketUser/repo"))
+      (it "gives precedence to :fork PLIST's :repo"
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:repo "/rename")))
+                :to-equal "githubUser/rename")
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:host github :repo "user/")))
+                :to-equal "user/repo")
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:host gitlab :repo "full/override")))
+                :to-equal "full/override")
+        ;; https://github.com/raxod502/straight.el/issues/592
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:host nil :repo "/local/repo")))
+                :to-equal "/local/repo"))
+      (it "looks up the user when :fork PLIST does not provide a :repo"
+        (expect (straight-vc-git--fork-repo
+                 (plist-put straight-test-default-recipe
+                            :fork '(:branch "feature")))
+                :to-equal "githubUser/repo")))))
 
 
 (provide 'straight-test)
 
 ;; Local Variables:
 ;; End:
-
-;;; straight-test.el ends here
-
 
 
 ;;; test-straight.el ends here


### PR DESCRIPTION
Added a few unit tests using buttercup. They can be run with `make test` from the straight repo directory. They do assume buttercup is installed, so we'd have to arrange for that if we wanted to run these on CI, but that should be easy to do with straight itself.

![image](https://user-images.githubusercontent.com/44036031/95390018-b64b5500-08c2-11eb-9178-a0ac046ee695.png)

Related: #478 #69 

Let me know what you think about this setup in general. If you like it, I'll try and get us covered on all the unit tests.