### PR TITLE
Add more existence checks for delete-directory

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2298,7 +2298,8 @@ clone of everything."
                  "git" "fetch" remote commit
                  "--depth" (number-to-string depth)
                  "--no-tags")))
-          (delete-directory repo-dir 'recursive)
+          (when (file-exists-p repo-dir)
+            (delete-directory repo-dir 'recursive))
           (straight--get-call
            "git" "clone" "--origin" remote
            "--no-checkout" url repo-dir
@@ -2308,7 +2309,8 @@ clone of everything."
            "--no-tags"))
       ;; Fallback for dumb http protocol.
       (error
-       (delete-directory repo-dir 'recursive)
+       (when (file-exists-p repo-dir)
+         (delete-directory repo-dir 'recursive))
        (straight-vc-git--clone-internal :depth 'full
                                         :remote remote
                                         :url url


### PR DESCRIPTION
As already seen in https://github.com/raxod502/straight.el/issues/287, on emacs 25 and earlier, delete-directory errors out if run on a non-existent directory.  So add more existence checks to prevent this.