### PR TITLE
Translate :branch from melpa recipes

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2803,6 +2803,8 @@ return nil."
                 (straight--put
                  plist :files
                  (append files (list (format "%S-pkg.el" package)))))
+              (when-let ((branch (plist-get melpa-plist :branch)))
+                (straight--put plist :branch branch))
               (pcase (plist-get melpa-plist :fetcher)
                 (`git (straight--put plist :repo (plist-get melpa-plist :url)))
                 ((or `github `gitlab)


### PR DESCRIPTION
A select few melpa recipes define a `:branch` property.  Stop dropping it on the floor when creating straight recipes from melpa recipes.