### PR TITLE
recipe conversion: use provided recipe for username lookup if  no default

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3133,10 +3133,11 @@ for dependency resolution."
             ;; not present in the override and adding them there.
             (let* ((sources (plist-get plist :source))
                    (default
-                     (cdr (straight-recipes-retrieve package
-                                                     (if (listp sources)
-                                                         sources
-                                                       (list sources)))))
+                     (or (cdr (straight-recipes-retrieve package
+                                                         (if (listp sources)
+                                                             sources
+                                                           (list sources))))
+                         plist))
                    (keywords
                     (append
                      (remq :local-repo straight--build-keywords)


### PR DESCRIPTION
Otherwise striaght--vc--host-username does not recieve enough
information to compute the :repo string.

See: #612

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
