### PR TITLE
Include branch when shallow clone fails

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2315,7 +2315,8 @@ clone of everything."
        (straight-vc-git--clone-internal :depth 'full
                                         :remote remote
                                         :url url
-                                        :repo-dir repo-dir))))
+                                        :repo-dir repo-dir
+                                        :branch branch))))
    (t (error "Invalid value %S of depth for %s" depth url))))
 
 ;;;;;; API


### PR DESCRIPTION
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->

If a shallow clone fails, the retried full clone will also fail because it's not passing the branch. Eg my local org-mode is pinned to 732aa477b031772c3694023cbf34eec6bdc08d61 ; a fresh clone results in this straight-process buffer:

```
$ cd /home/sjung/.config/emacs/straight/repos/org/
$ git init

Initialized empty Git repository in /home/sjung/.config/emacs/straight/repos/org/.git/

[Return code: 0]

$ cd /home/sjung/.config/emacs/straight/repos/org/
$ git remote add origin https\://code.orgmode.org/bzg/org-mode.git --master master

[Return code: 0]

$ cd /home/sjung/.config/emacs/straight/repos/org/
$ git fetch origin 732aa477b031772c3694023cbf34eec6bdc08d61 --depth 1 --no-tags

error: Server does not allow request for unadvertised object 732aa477b031772c3694023cbf34eec6bdc08d61

[Return code: 128]

$ cd /home/sjung/.config/emacs/straight/repos/
```

Then the second clone attempt fails because branch is nil:

```
Debugger entered--Lisp error: (wrong-type-argument arrayp nil)
  substring(nil 0 0)
  replace-regexp-in-string("[^-0-9a-zA-Z_./\n]" "\\\\\\&" nil)
  shell-quote-argument(nil)
  mapconcat(shell-quote-argument ("git" "clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/") " ")
  straight--process-run("git" "clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/")
  apply(straight--process-run "git" ("clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/"))
  straight--call("git" "clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/")
  apply(straight--call "git" ("clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/"))
  straight--get-call-raw("git" "clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/")
  apply(straight--get-call-raw "git" ("clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/"))
  straight--get-call("git" "clone" "--origin" "origin" "--branch" nil "--no-checkout" "https://code.orgmode.org/bzg/org-mode.git" "/home/sjung/.config/emacs/straight/repos/org/")
  straight-vc-git--clone-internal(:depth full :remote "origin" :url "https://code.orgmode.org/bzg/org-mode.git" :repo-dir "/home/sjung/.config/emacs/straight/repos/org/")
  straight-vc-git--clone-internal(:depth 1 :remote "origin" :url "https://code.orgmode.org/bzg/org-mode.git" :repo-dir "/home/sjung/.config/emacs/straight/repos/org/" :branch "master" :commit "732aa477b031772c3694023cbf34eec6bdc08d61")
  straight-vc-git-clone((:type git :repo "https://code.orgmode.org/bzg/org-mode.git" :local-repo "org" :package "org") "732aa477b031772c3694023cbf34eec6bdc08d61")
  apply(straight-vc-git-clone ((:type git :repo "https://code.orgmode.org/bzg/org-mode.git" :local-repo "org" :package "org") "732aa477b031772c3694023cbf34eec6bdc08d61"))
  straight-vc(clone git (:type git :repo "https://code.orgmode.org/bzg/org-mode.git" :local-repo "org" :package "org") "732aa477b031772c3694023cbf34eec6bdc08d61")
  straight-vc-clone((:type git :repo "https://code.orgmode.org/bzg/org-mode.git" :local-repo "org" :package "org"))
  straight--clone-repository((:type git :repo "https://code.orgmode.org/bzg/org-mode.git" :local-repo "org" :package "org") nil)
```