### PR TITLE
"straight--convert-recipe: ignore straight-vc-keywords for built-in p…

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3138,11 +3138,12 @@ for dependency resolution."
                                                              sources
                                                            (list sources))))
                          plist))
+                   (type (or (plist-get default :type) 'git))
                    (keywords
                     (append
                      (remq :local-repo straight--build-keywords)
-                     (straight-vc-keywords
-                      (or (plist-get default :type) 'git)))))
+                     (unless (eq type 'built-in)
+                       (straight-vc-keywords type)))))
               ;; Compute :fork repo name
               (when-let ((fork (plist-get plist :fork)))
                 (straight--put default :fork fork)


### PR DESCRIPTION
…ackages"

There are no keywords implemented for the built-in package type.
Calling straight-vc-keywords will error with this type.

See: #617

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
