### PR TITLE
straight-bug-report: error when lexical binding nil

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6378,6 +6378,8 @@ ARGS may be any of the following keywords and their respective values:
 ARGS are accessible within the :pre/:post-bootsrap phases via the
 locally bound plist, straight-bug-report-args."
   (declare (indent 0))
+  (unless lexical-binding
+    (user-error "Lexical binding required for straight-bug-report"))
   (let* ((preserve-files    (make-symbol "preserve-files"))
          (temp-emacs-dir    (make-symbol "temp-emacs-dir"))
          (interactive       (make-symbol "interactive"))


### PR DESCRIPTION
Lexical binding is required for the sentinel function to work properly.
Rather than letting the subprocess launch and waste work, just throw a
user-error if straight-bug-report is executed without lexical binding
enabled.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
