### PR TITLE
straight-bug-report: switch buffer on idle timer

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6460,8 +6460,10 @@ locally bound plist, straight-bug-report-args."
         :sentinel (lambda (_process _event)
                     (unless ,interactive
                       (unless ,raw (straight-bug-report--format ,report))
-                      (switch-to-buffer-other-window
-                       straight-bug-report--process-buffer))
+                      (run-with-idle-timer
+                       1 nil (lambda ()
+                               (switch-to-buffer-other-window
+                                straight-bug-report--process-buffer))))
                     (unless ,preserve-files
                       (when (file-exists-p ,temp-emacs-dir)
                         (delete-directory ,temp-emacs-dir 'recursive)))))


### PR DESCRIPTION
Prevents results buffer from stealing focus if user is doing something
else, e.g. typing while a longer running test is running.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
