### PR TITLE
Fix defcustom for straight-check-for-modifications

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3456,7 +3456,7 @@ follows:
 
 This usage is deprecated and will be removed."
   :type
-  '(list
+  '(repeat
     (choice
      (const :tag "Use find(1) at startup" find-at-startup)
      (const :tag "Use find(1) in \\[straight-check-package]"


### PR DESCRIPTION
A `:type` of `'(list ...)` fixes the number of elements, so anything other than a singleton list resulted in `(mismatch)` in the Custom buffer.  So change to `'(repeat ...)` to allow a variable number of symbols in the list.