### PR TITLE
Fix installation issue on Windows

### DIFF
--- a/install.el
+++ b/install.el
@@ -161,7 +161,7 @@
       ;; All of the following code is actually executed by the child
       ;; Emacs.
       (goto-char (point-min))
-      (prin1 ";; -*- coding: utf-8 -*-" (current-buffer))
+      (princ ";; -*- coding: utf-8 -*-" (current-buffer))
       (print
        `(progn
           ;; Pass relevant variables into the child Emacs, if they

--- a/install.el
+++ b/install.el
@@ -161,6 +161,7 @@
       ;; All of the following code is actually executed by the child
       ;; Emacs.
       (goto-char (point-min))
+      (prin1 ";; -*- coding: utf-8 -*-" (current-buffer))
       (print
        `(progn
           ;; Pass relevant variables into the child Emacs, if they


### PR DESCRIPTION
Due to the way handling Unicode on Windows, the evaluation of `straight.el` could fail in some cases. Adding comment `;; -*- coding: utf-8 -*-` will force the encoding, therefore could solve this problem.