### PR TITLE
Refactor/straight  build functions

### DIFF
--- a/bootstrap.el
+++ b/bootstrap.el
@@ -23,7 +23,7 @@
        (straight.el
         (expand-file-name
          "straight.el" (file-name-directory bootstrap.el))))
-  ;; This logic replicates that in `straight--byte-compile-package',
+  ;; This logic replicates that in `straight--build-compile',
   ;; and is used to silence byte-compile warnings and other cruft.
   (cl-letf (((symbol-function #'save-some-buffers) #'ignore)
             ((symbol-function #'byte-compile-log-1) #'ignore)
@@ -81,31 +81,31 @@
 
 (straight-use-recipes '(melpa :type git :host github
                               :repo "melpa/melpa"
-                              :no-build t))
+                              :build nil))
 
 (if straight-recipes-gnu-elpa-use-mirror
     (straight-use-recipes
      '(gnu-elpa-mirror :type git :host github
                        :repo "emacs-straight/gnu-elpa-mirror"
-                       :no-build t))
+                       :build nil))
   (straight-use-recipes `(gnu-elpa :type git
                                    :repo ,straight-recipes-gnu-elpa-url
                                    :local-repo "elpa"
-                                   :no-build t)))
+                                   :build nil)))
 
 (straight-use-recipes '(el-get :type git :host github
                                :repo "dimitri/el-get"
-                               :no-build t))
+                               :build nil))
 
 (if straight-recipes-emacsmirror-use-mirror
     (straight-use-recipes
      '(emacsmirror-mirror :type git :host github
                           :repo "emacs-straight/emacsmirror-mirror"
-                          :no-build t))
+                          :build nil))
   (straight-use-recipes '(emacsmirror :type git :host github
                                       :repo "emacsmirror/epkgs"
                                       :nonrecursive t
-                                      :no-build t)))
+                                      :build nil)))
 
 ;; Then we register (and build) straight.el itself.
 (straight-use-package `(straight :type git :host github


### PR DESCRIPTION
An implementation of what I was suggesting with #659 and #655.
The README will need to be reworded, but I figured we could discuss the viability of such an approach before making substantial edits.

A recipe may specify build steps via the `:build` keyword.
(Note the original `:build` keyword has been renamed to `:pre-build`)

The `:build` keyword accepts the following values:

- `nil`
No build is executed. `:pre-build` and `:post-build` commands are not run.

```emacs-lisp
     (example :build nil)
```

- `t`
Equivalent to running `straight--default-build-steps` (see below).

- `(step...)`
Each step in the list is a symbol which represents a function named `straight--build-SYMBOL`.
The function is passed the recipe as its sole argument.
Steps are executed in the order they are listed.

```emacs-lisp
(example :build (autoloads compile native-compile info))
```

- `(:not step...)`
  If the car of the list is the `:not` keyword, the build steps are the
  set difference of `straight--build-default-steps` and the cdr of the
  recipe's `:build` list.
  e.g. with `straight--build-default-steps` set to:

```emacs-lisp
(autoloads compile native-compile info)
```

   and the following recipe:

```emacs-lisp
(example :build (:not compile info))
```

  the package is not byte compiled and does not have it's texinfo generated.

  Steps may be disabled globally via the customization variable named
  `straight-disable-SYMBOL`. e.g.:

```emacs-lisp
(setq straight-disable-info t)
;;info generation disabled when :build is not explicitly declared
(straight-use-package '(example))
;;or starts with :not
;;Info disabled in addition to compilation.
(straight-use-package '(example :build (:not compile)))
```

In the absence of a `:build` keyword, `straight--build-default-steps` are run.
