### PR TITLE
Full clone Org in default recipes

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2807,6 +2807,8 @@ Otherwise return nil."
     (let* ((form
             '`(org :type git
                    :repo "https://code.orgmode.org/bzg/org-mode.git"
+                   ;; `org-version' depends on repository tags.
+                   :depth full
                    ;; Org's make autoloads generates org-verison.el.
                    :no-autoloads t
                    :local-repo "org"
@@ -2830,7 +2832,7 @@ Otherwise return nil."
 
 (defun straight-recipes-org-elpa-version ()
   "Return the current version of the Org ELPA retriever."
-  3)
+  4)
 
 ;;;;;; MELPA
 


### PR DESCRIPTION
The org-version command depends on repository tags.
Using a shallow clone will cause this command (and others) to fail.

See:
https://orgmode.org/list/87y2h6yafs.fsf@kyleam.com/T/#t
https://github.com/raxod502/straight.el/issues/667

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
