### PR TITLE
Add :includes keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -1872,7 +1872,7 @@ differences from the user's point of view are:
 * There are consistency and feature improvements to edge cases of the
   `:files` keyword as documented in `straight-expand-files-directive`.
 
-* `:includes` indicates a package is a superset of another package
+* `:includes` indicates a package is a superset of another package.
 
 Here is a comprehensive list of all keywords which have special
 meaning in a recipe (unknown keywords are ignored but preserved):

--- a/README.md
+++ b/README.md
@@ -1872,6 +1872,8 @@ differences from the user's point of view are:
 * There are consistency and feature improvements to edge cases of the
   `:files` keyword as documented in `straight-expand-files-directive`.
 
+* `:includes` indicates a package is a superset of another package
+
 Here is a comprehensive list of all keywords which have special
 meaning in a recipe (unknown keywords are ignored but preserved):
 
@@ -2068,6 +2070,23 @@ In the absence of a `:build` keyword, `straight--build-default-steps` are run.
   meaningful. See the next section.
 
   The `built-in` pseudo-backend does not take any other keywords.
+
+* `:includes`
+
+Informs straight that a package is a superset of another package.
+For example `org-plus-contrib` includes `org`.
+The following will prevent `straight.el` from attempting to install `org`
+after `org-plus-contrib` has been installed:
+
+```emacs-lisp
+(straight-use-package '(org-plus-contrib :includes org))
+```
+
+It's value may also be a list of symbols indicating multiple packages:
+
+```emacs-lisp
+(straight-use-package '(example :includes (foo bar)))
+```
 
 #### Version-control backends
 

--- a/README.md
+++ b/README.md
@@ -2082,7 +2082,7 @@ after `org-plus-contrib` has been installed:
 (straight-use-package '(org-plus-contrib :includes org))
 ```
 
-It's value may also be a list of symbols indicating multiple packages:
+Its value may also be a list of symbols indicating multiple packages:
 
 ```emacs-lisp
 (straight-use-package '(example :includes (foo bar)))

--- a/README.md
+++ b/README.md
@@ -2073,7 +2073,7 @@ In the absence of a `:build` keyword, `straight--build-default-steps` are run.
 
 * `:includes`
 
-Informs straight that a package is a superset of another package.
+Informs `straight.el` that a package is a superset of another package.
 For example `org-plus-contrib` includes `org`.
 The following will prevent `straight.el` from attempting to install `org`
 after `org-plus-contrib` has been installed:

--- a/straight.el
+++ b/straight.el
@@ -2804,27 +2804,27 @@ Return a list of package names as strings."
 PACKAGE must be either `org' or `org-plus-contrib'.
 Otherwise return nil."
   (when (member package '(org org-plus-contrib))
-    (let* ((form
-            '`(org :type git
-                   :repo "https://code.orgmode.org/bzg/org-mode.git"
-                   ;; `org-version' depends on repository tags.
-                   :depth full
-                   ;; Org's make autoloads generates org-verison.el.
-                   :build (:not autoloads)
-                   :local-repo "org"
-                   :pre-build
-                   ,(list
-                     (concat (when (eq system-type 'berkeley-unix) "g")
-                             "make")
-                     "autoloads"
-                     (concat "EMACS=" invocation-directory invocation-name))))
-           (recipe (cadr form)))
-      (setcdr recipe
-              (plist-put (cdr recipe)
-                         :files (append '(:defaults "lisp/*.el")
-                                        (when (eq package 'org-plus-contrib)
-                                          '("contrib/lisp/*.el")))))
-      form)))
+    (list '\`
+          (append
+           (list package
+                 :type 'git
+                 :repo "https://code.orgmode.org/bzg/org-mode.git"
+                 :local-repo "org"
+                 ;; `org-version' depends on repository tags.
+                 :depth 'full
+                 :pre-build
+                 ',(list
+                    (concat (when (eq system-type 'berkeley-unix) "g")
+                            "make")
+                    "autoloads"
+                    (concat "EMACS=" invocation-directory invocation-name))
+                 ;; Org's make autoloads generates org-verison.el.
+                 :build '(:not autoloads)
+                 :files (append '(:defaults "lisp/*.el")
+                                (when (eq package 'org-plus-contrib)
+                                  '("contrib/lisp/*.el"))))
+           (when (eq package 'org-plus-contrib)
+             '(:includes org))))))
 
 (defun straight-recipes-org-elpa-list ()
   "Return a list of Org ELPA pseudo-packages, as a list of strings."
@@ -2832,7 +2832,7 @@ Otherwise return nil."
 
 (defun straight-recipes-org-elpa-version ()
   "Return the current version of the Org ELPA retriever."
-  5)
+  6)
 
 ;;;;;; MELPA
 
@@ -3448,8 +3448,7 @@ nil."
 (defun straight--register-recipe (recipe)
   "Make the various caches aware of RECIPE.
 RECIPE should be a straight.el-style recipe plist."
-  (straight--with-plist recipe
-      (package local-repo type)
+  (straight--with-plist recipe (package local-repo type)
     ;; Skip conflict detection for built-in packages.
     (unless (eq type 'built-in)
       ;; Step 1 is to check if the given recipe conflicts with an
@@ -3515,6 +3514,18 @@ RECIPE should be a straight.el-style recipe plist."
     ;; while later, or never, depending on the values of NO-CLONE and
     ;; NO-BUILD that were passed to `straight-use-package'.
     (puthash package recipe straight--recipe-cache)
+    ;; register recipes covered by :includes
+    (when-let ((includes (plist-get recipe :includes)))
+      (dolist (included (mapcar #'symbol-name
+                                (if (listp includes)
+                                    includes (list includes))))
+        (puthash included
+                 (list :package included
+                       :type type
+                       :build nil
+                       :local-repo nil
+                       :included-by package)
+                 straight--recipe-cache)))
     ;; Don't record recipes which have no local repositories.
     (when local-repo
       (puthash local-repo recipe straight--repo-cache))


### PR DESCRIPTION
Used to indicate one package is a superset of another. Originally mentioned in #352 and seems to have proliferated via copy+paste:

https://github.com/raxod502/straight.el/issues/624#issuecomment-729291385
https://github.com/syl20bnr/spacemacs/pull/14240
https://github.com/search?q=straight-use-package+org-plus-contrib+%3Aincludes&type=Code

 