### PR TITLE
 straight--compute-dependencies: use more forgiving regexp

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4665,7 +4665,7 @@ this run of straight.el)."
                  ;; missing or malformed, we just assume the package
                  ;; has no dependencies.
                  (let ((case-fold-search t))
-                   (re-search-forward "^;; *Package-Requires *: *"))
+                   (re-search-forward "^;* *Package-Requires *: *"))
                  (when (looking-at "(")
                    (straight--process-dependencies
                     (read (current-buffer)))))))))


### PR DESCRIPTION
If a package author adds more semi-colons to the package header line, we are dropping the package dependencies.
This is one of those cases where I'd consider it a bug in the author's package (though, it's more of a convention than anything technical), but also our bug because I can't think of a reason not to use a more forgiving regexp to find the `Package-Requires` line. Adjusted so any number of semi-colons at the start of the metadata are matched.


see: #682, https://github.com/zainab-ali/pair-tree.el/issues/1