### PR TITLE
correctly judge desired origin url when use GIT proxy

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -1881,7 +1881,8 @@ necessarily need to match DESIRED-URL; it just has to satisfy
   (ignore
    (if-let ((actual-url (condition-case nil
                             (straight--get-call
-                             "git" "remote" "get-url" remote)
+                             "git" "config" "--get"
+                             (format "remote.%s.url" remote))
                           (error nil))))
        (if (straight-vc-git--urls-compatible-p
             actual-url desired-url)


### PR DESCRIPTION
I use a proxy to accelerate git clone and fetch from Github for Doom Emacs,
straight.el always reports inconsistence between desired origin url of
`melpa/melpa.git` and actual remote origin url.  According to commands
below, it's obvious straight.el should use `git config --get` instead of
`git remote get-url`.

```
$ git config --global url.https://github.com.cnpmjs.org/.insteadOf https://github.com/

$ git config --get remote.origin.url
https://github.com/raxod502/straight.el

$ git remote get-url origin
https://github.com.cnpmjs.org/raxod502/straight.el
```

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
