### PR TITLE
Refuse to load if git executable not found.

### DIFF
--- a/install.el
+++ b/install.el
@@ -85,6 +85,9 @@
       (error "The `straight-repository-branch' must be a string (was: %S)"
              straight-repository-branch)))
 
+  (unless (executable-find "git")
+    (user-error "Git executable not found. straight.el requires git"))
+
   ;; Load some libraries.
   (require 'cl-lib)
   (require 'url-http)

--- a/straight.el
+++ b/straight.el
@@ -48,6 +48,9 @@
            ,(eval-when-compile (emacs-version)))
     (throw 'emacs-version-changed nil)))
 
+(unless (executable-find "git")
+  (user-error "Git executable not found. straight.el requires git"))
+
 ;;;; Libraries
 
 (require 'cl-lib)


### PR DESCRIPTION
If the user does not have git installed or it is not on the `exec-path` we can error sooner.
This should help us pinpoint those types of bugs sooner.
See #665