### PR TITLE
[raxod502/selectrum#437] Use default outline-regexp

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6676,5 +6676,4 @@ locally bound plist, straight-bug-report-args."
 ;; checkdoc-symbol-words: ("byte-compile" "top-level")
 ;; checkdoc-verb-check-experimental-flag: nil
 ;; indent-tabs-mode: nil
-;; outline-regexp: ";;;;* "
 ;; End:

--- a/straight.el
+++ b/straight.el
@@ -6670,10 +6670,10 @@ locally bound plist, straight-bug-report-args."
 
 (provide 'straight)
 
-;;; straight.el ends here
-
 ;; Local Variables:
 ;; checkdoc-symbol-words: ("byte-compile" "top-level")
 ;; checkdoc-verb-check-experimental-flag: nil
 ;; indent-tabs-mode: nil
 ;; End:
+
+;;; straight.el ends here


### PR DESCRIPTION
See https://github.com/raxod502/selectrum/issues/437. I don't quite understand why it's so harmful to set `outline-regexp` in a file-local variable, but if Jonas says it's a bad idea, I trust him.
