### PR TITLE
straight-recipes-org-elpa--build: avoid shell-command-to-string

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2832,9 +2832,8 @@ See: https://github.com/raxod502/straight.el/issues/707"
          (orgversion
           (replace-regexp-in-string
            "release_" ""
-           (string-trim
-            (shell-command-to-string
-             "git describe --match release\* --abbrev=0 HEAD"))))
+           (straight--get-call "git" "describe" "--match" "release\*"
+                               "--abbrev=0" "HEAD")))
          (gitversion
           (concat
            orgversion "-g"


### PR DESCRIPTION
Prevents breakage due to globbing with different shells (e.g. ZSH).
See: #713

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
