### PR TITLE
[#715] Remove unnecessary backslash

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2834,7 +2834,7 @@ See: https://github.com/raxod502/straight.el/issues/707"
          (orgversion
           (replace-regexp-in-string
            "release_" ""
-           (straight--get-call "git" "describe" "--match" "release\*"
+           (straight--get-call "git" "describe" "--match" "release*"
                                "--abbrev=0" "HEAD")))
          (gitversion
           (concat


### PR DESCRIPTION
This wasn't doing anything even before https://github.com/raxod502/straight.el/pull/715, which was probably the reason for https://github.com/raxod502/straight.el/issues/713 in the first place. The backslash needs to be doubled `\\` to be passed through to the actual shell. But now that we're not using a shell we don't need any escaping.

