### PR TITLE
Bootstrap attempts to load straight eln then elc

### DIFF
--- a/bootstrap.el
+++ b/bootstrap.el
@@ -43,9 +43,9 @@
         ;; `emacs-version-changed' if the version of Emacs has changed
         ;; since the last time it was byte-compiled. This prevents us
         ;; from accidentally loading invalid byte-code, hopefully.
-        (load (expand-file-name (concat straight.el "c")
-                                default-directory)
-              nil 'nomessage 'nosuffix)
+        (load (file-name-sans-extension
+               (expand-file-name straight.el default-directory))
+              nil 'nomessage)
         (setq emacs-version-changed nil))
       (when emacs-version-changed
         ;; In safe mode, sacrifice performance for safety.
@@ -54,9 +54,9 @@
           ;; Don't use the optional LOAD argument for
           ;; `byte-compile-file' because it emits a message.
           (byte-compile-file straight.el)
-          (load (expand-file-name (concat straight.el "c")
-                                  default-directory)
-                nil 'nomessage 'nosuffix))))))
+          (load (file-name-sans-extension
+                 (expand-file-name straight.el default-directory))
+                nil 'nomessage))))))
 
 ;; This assures the byte-compiler that we know what we are doing when
 ;; we reference functions and variables from straight.el below. It


### PR DESCRIPTION
Works around #724, should effectively fix #697 and #643 as well (though most of that fix was upstream)

This allows Emacs to first attempt to load eln, then elc. It will fall back to el if neither exist, but the `byte-recompile-file` should eliminate that possibility.

Theoretically this is "slower" because it does a few more file existence checks based on `load-suffixes`, but in practice it's unlikely to be noticeable for one file and it eliminates the need to check for native compilation support and load that explicitly.

I still need to do a little looking into the file modification check to make sure it actually fixes #697 and #643
