### PR TITLE
Default branch when init on commit

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2466,7 +2466,7 @@ clone of everything."
                 (apply #'straight--process-output
                        "git" "remote" "add" remote url
                        (when branch `("--master" ,branch)))
-                (when (not branch)
+                (unless branch
                   (straight--process-output
                    "git" "branch" "-m"
                    (straight-vc-git--default-remote-branch remote repo-dir)))

--- a/straight.el
+++ b/straight.el
@@ -2461,10 +2461,15 @@ clone of everything."
               (make-directory repo-dir)
               (let ((straight--default-directory nil)
                     (default-directory repo-dir))
-                (straight--process-output "git" "init")
+                (apply #'straight--process-output
+                       "git" "init" (when branch `("-b" ,branch)))
                 (apply #'straight--process-output
                        "git" "remote" "add" remote url
                        (when branch `("--master" ,branch)))
+                (when (not branch)
+                  (straight--process-output
+                   "git" "branch" "-m"
+                   (straight-vc-git--default-remote-branch remote repo-dir)))
                 (straight--process-output
                  "git" "fetch" remote commit
                  "--depth" (number-to-string depth)


### PR DESCRIPTION
This is related to #630, but tackles a different issue regarding default branches: When cloning a repo at a specific commit, the repos isn't cloned but initiated and then the remote is added. That means if the default init branch (`init.defaultBranch` or `master`) isn't the same as the remote default branch, there's a branch mismatch. One might argue that it doesn't matter, as a specific commit is requested, however in practice it does: Emacs doom (using straight.el) fails on subsequent updates of a repo created like this (which may be a bug on its own). I believe using the remote default branch as proposed in this PR is a more sane/helpful starting point.