### PR TITLE
straight-disable-native-compile: Set default dynamcially

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5058,7 +5058,8 @@ repository."
 (define-obsolete-variable-alias 'straight-disable-native-compilation
   'straight-disable-native-compile "2021-01-01")
 
-(defcustom straight-disable-native-compile nil
+(defcustom straight-disable-native-compile
+  (not (and (fboundp 'native-comp-available-p) (native-comp-available-p)))
   "Non-nil means do not `native-compile' packages by default.
 This can be overridden by the `:build' property of an
 individual package recipe."


### PR DESCRIPTION
Instead of checking during every recipe build for Emacs versions which do not have native compilation enabled, we can set this
variable's default value once.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
