### PR TITLE
Monitor correct directory for changes

### DIFF
--- a/watcher/straight_watch.py
+++ b/watcher/straight_watch.py
@@ -47,7 +47,16 @@ def write_process_data(pid_file):
 def start_watch(repos_dir, modified_dir):
     callback_cmd = [CALLBACK_SCRIPT, repos_dir, modified_dir]
     callback_sh = " ".join(map(shlex.quote, callback_cmd))
-    cmd = ["watchexec", "--no-vcs-ignore", "-p", "-d", "100", callback_sh]
+    cmd = [
+        "watchexec",
+        "--no-vcs-ignore",
+        "-p",
+        "-d",
+        "100",
+        "-w",
+        repos_dir,
+        callback_sh,
+    ]
     cmd_sh = " ".join(map(shlex.quote, cmd))
     print("$ " + cmd_sh, file=sys.stderr)
     subprocess.run(cmd, cwd=repos_dir, check=True)


### PR DESCRIPTION
It's unclear to me how this was working before, but I noticed that my modifications were not being detected, investigated, and discovered that the filesystem watcher was being started in `~/.emacs.d/straight/watcher`, when it needed to be watching `~/.emacs.d/straight/repos`:

https://github.com/raxod502/straight.el/blob/b4effa92f82c60fe4e3d97e0f2ba3db473ae164c/straight.el#L4215

Notably, if we extend the watchexec command line like in this pull request but with multiple `-w` arguments, then we can properly support the filesystem watcher for repositories with custom `:local-repo` paths (outside of `~/.emacs.d/straight/repos`, that is).