### PR TITLE
Remove straight--normalize-alist

### DIFF
--- a/tests/test-straight.el
+++ b/tests/test-straight.el
@@ -47,21 +47,6 @@ return nil."
                          :match (eval (car (get var 'standard-value)) t))
            :to-be t))))))
 
-(describe "straight--normalize-alist"
-  (describe "(alist)"
-    (it "does not mutate ALIST"
-      (expect (let ((alist '((a . b) (a . c))))
-                (straight--normalize-alist '((a . b) (a . c)))
-                alist)
-              :to-equal '((a . b) (a . c))))
-    (it "removes duplicate keys"
-      (expect (straight--normalize-alist '((a . b) (a . c)))
-              :to-equal '((a . c)))))
-  (describe "(alist test)"
-    (it "respects TEST function"
-      (expect (straight--normalize-alist '(("a" . b) ("a" . c)) #'equal)
-              :to-equal '(("a" . c))))))
-
 (describe "straight--alist-set"
   (describe "(key val alist)"
     (it "adds (KEY . VAL) to front of ALIST"


### PR DESCRIPTION
Function is only called during `straight-expand-files-directive`.
We can use `cl-pushnew` instead.

I believe this will be equivalent. Seem OK to you @raxod502?