### PR TITLE
straight-recipes-org-elpa--build: Fix orgversion string.

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3048,11 +3048,13 @@ This is to avoid relying on `make` on Windows.
 See: https://github.com/raxod502/straight.el/issues/707"
   (let* ((default-directory (straight--repos-dir "org" "lisp"))
          (orgversion
-          (straight--process-output
-           "emacs" "-Q" "--batch"
-           "--eval" "(require 'lisp-mnt)"
-           "--visit" "org.el"
-           "--eval" "(princ (lm-header \"version\"))"))
+          (replace-regexp-in-string
+           "-dev" ""
+           (straight--process-output
+            "emacs" "-Q" "--batch"
+            "--eval" "(require 'lisp-mnt)"
+            "--visit" "org.el"
+            "--eval" "(princ (lm-header \"version\"))")))
          (gitversion
           (concat orgversion "-g" (straight--process-output
                                    "git" "rev-parse" "--short=6" "HEAD")))


### PR DESCRIPTION
Fixes hand-me-down bug I got for copying over Org's own make machinery.
Reported upstream with patch: https://orgmode.org/list/874kab2js1.fsf@gmail.com/#t
However, since we're bypassing Make altogether we can fix it
independent of upstream.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
