### PR TITLE
use main branch for org

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3088,6 +3088,7 @@ Otherwise return nil."
      (list package
            :type 'git
            :repo "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+           :branch "main"
            :local-repo "org"
            ;; `org-version' depends on repository tags.
            :depth 'full


### PR DESCRIPTION
Four days ago 0b0dcf8c19facd5f546e606d528408fb40e7c2d2 changed the git repo for org without also changing the git branch which I think is supposed to be "main" rather than "master".
This PR sets the git branch to be "main".

It appears that GNU projects are slowly migrating branch names from "master" to "main".  Some time ago elpa git repository switched from "master" to "main".  It appears that org-mode now followed that lead.