### PR TITLE
test: Add unit tests, mocks; Improve straight-deftest

### DIFF
--- a/tests/mocks/.emacs.d/straight/build/straight-mock-repo/straight-mock-repo.el
+++ b/tests/mocks/.emacs.d/straight/build/straight-mock-repo/straight-mock-repo.el
@@ -1,0 +1,1 @@
+/home/n/.emacs.d/straight/repos/straight.el/tests/mocks/.emacs.d/straight/repos/straight-mock-repo/straight-mock-repo.el

--- a/tests/mocks/.emacs.d/straight/repos/straight-mock-repo/straight-mock-repo.el
+++ b/tests/mocks/.emacs.d/straight/repos/straight-mock-repo/straight-mock-repo.el
@@ -1,0 +1,30 @@
+;;; straight-mock-repo.el --- A mock package -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021
+
+;; Author:
+;; Keywords: data
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary: Mock package for testing
+
+;;
+
+;;; Code:
+
+
+
+(provide 'straight-mock-repo)
+;;; straight-mock-repo.el ends here


### PR DESCRIPTION
Add mocks subdirectory, mock repo and package.

straight-deftest:
  Allow single form for :before/:after-each.
  Auto tag template tests with object name.
  Allows running all of object's tests with the (tag OBJECT) selector.

Test units:
  straight--add-package-to-info-path
  straight--autoloads-file
  straight--build-cache-file
  straight--build-dir
  straight--build-disabled-p
  straight--buildable-p
  straight--catching-quit

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
