### PR TITLE
Remove checkindent test from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ shared: &shared
     - run: >-
         make docker
         CMD="EMACS_DOCKER=t make -k compile checkdoc longlines
-        checkindent test smoke"
+        test smoke"
 jobs:
   emacs-25:
     <<: *shared


### PR DESCRIPTION
Due to upstream change in emacs-lisp-mode indentation:

https://github.com/emacs-mirror/emacs/commit/32df2034234056bf24312ef5883671b59a387520

Our checkindent test will fail across Emacs versions. They no longer
agree on the appropriate indentation for bindings starting with
"def" (e.g. default-directory) in all cases. Fixing the indentation
in one version (e.g. 29) will break the indentation in previous
versions (and vice versa if the program is indented to satisfy earlier
versions).

Fixes: #902

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
