### PR TITLE
bug-report-package-info: Don't assume :type git

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6842,11 +6842,13 @@ Info is a plist of form:
             (source (straight-recipe-source package))
             (version
              (when repo
-               (let ((default-directory (straight--repos-dir repo)))
-                 (format "%s %s"
-                         (straight-vc-git--local-branch "HEAD")
-                         (straight--process-output
-                          "git" "show" "-s" "--format=%h %cs"))))))
+               (ignore-errors
+                 (let ((default-directory (straight--repos-dir repo)))
+                   (format "%s %s"
+                           ;;@FIXME: shouldn't rely on vc-git specifically here
+                           (straight-vc-git--local-branch "HEAD")
+                           (straight--process-output
+                            "git" "show" "-s" "--format=%h %cs")))))))
        (append
         (list :package package)
         (when source (list :source source))


### PR DESCRIPTION
Otherwise, a recipe with :type nil will throw an error when trying to get the local branch
since we may not be in a git repository.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
