### PR TITLE
use invocation-name rather than just "emacs"

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3060,7 +3060,8 @@ See: https://github.com/raxod502/straight.el/issues/707"
                 ;; backup in case Org repo has no tags
                 (straight--process-with-result
                     (straight--process-run
-                     "emacs" "-Q" "--batch"
+                     (expand-file-name invocation-name invocation-directory)
+                     "-Q" "--batch"
                      "--eval" "(require 'lisp-mnt)"
                      "--visit" "org.el"
                      "--eval" "(princ (lm-header \"version\"))")


### PR DESCRIPTION
When launching emacs sub-process to build org package, use emacs that is currently running rather than "emacs" found in current PATH. Why? Because emacs in current path my be different than currently running emacs. For example /usr/bin/emacs is 24.3 on CentOS 7, but I use my own build of emacs 28 which is launched via wrapper shell script. When emacs 28 tries to build org package, then it ends up launching emacs 24 as sub-process which cannot deal with modern org mode.  The proposed change is to make sure that currently running emacs is launched instead.
