### PR TITLE
straight--build-autoloads: Prevent spurious parens in autoloads

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5039,7 +5039,10 @@ modifies the build folder, not the original repository."
               (write-file-functions nil)
               ;; Apparently fixes a bug in Emacs 27, see
               ;; <https://github.com/raxod502/straight.el/issues/434>.
-              (debug-on-error nil))
+              (debug-on-error nil)
+              ;; Non-nil interferes with autoload generation in Emacs < 29, see
+              ;; <https://github.com/raxod502/straight.el/issues/904>.
+              (left-margin 0))
           ;; Actually generate the autoload file.
           ;; Emacs > 28.1 replaces `update-directory-autoloads' with
           ;; `make-directory-autoloads'


### PR DESCRIPTION
When non-nil, the left-margin variable may cause an extra opening
paren to be added to generated autoload files. This has been addressed
upstream in Emacs as of:

https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=fd5fe11211a469c42fb7142f5a26f577e8ff0010b

This patch prevents the problem in Emacs versions < 29.

See: #904 
