### PR TITLE
Watcher path concatenation is corrected

### DIFF
--- a/watcher/straight_watch_callback.py
+++ b/watcher/straight_watch_callback.py
@@ -51,10 +51,7 @@ def main(args):
         die("straight_watch_callback.py: watchexec gave no modified files")
     if WATCHEXEC_VAR_COMMON in os.environ:
         common = os.environ[WATCHEXEC_VAR_COMMON]
-        # Yes, string concatentation. For some reason when a common
-        # prefix is used, the individual paths start with a slash even
-        # though they're actually relative to the prefix.
-        paths = [common + path for path in paths]
+        paths = [os.path.join(common, path) for path in paths]
     paths = [pathlib.Path(path).resolve() for path in paths]
     paths = sorted(set(paths))
     repos = set()


### PR DESCRIPTION
Without this, I am getting modified files in the modified directory without a slash between parts: `nano-themenano-theme.el`, for example, rather than `nano-theme/nano-theme.el`. I am on `watchexec 1.18.6`. 