### PR TITLE
Prompt for SSH passphrases in minibuffer

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3006,7 +3006,8 @@ return nil."
                                   (if (file-directory-p d) d
                                     default-directory))
                               default-directory))
-         (branch-list (straight--process-output "git" "--no-pager" "branch" "-r")))
+         (branch-list
+          (straight--process-output "git" "--no-pager" "branch" "-r")))
     (if (string-match "^.*origin/HEAD -> origin/\\(.*$\\)" branch-list)
         (match-string 1 branch-list)
       ;; git doesn't always have the default remote branch name


### PR DESCRIPTION
It's finally here. Six years in the making. Closes https://github.com/radian-software/straight.el/issues/334. Replaces https://github.com/radian-software/straight.el/commit/00ee2d4abc097eba25dd7092e0613c2b93dad114 and https://github.com/radian-software/straight.el/commit/f18e581af9763f9ec6e5686f5505bda6e429579a. Fully compatible with the new process management API. Handles stdout and stderr properly.

Use `(setq straight-display-subprocess-prompts t)` to opt in and test it out.

![image](https://github.com/user-attachments/assets/0355f8c2-4b13-4beb-a006-e5dbfe8d175d)
