### PR TITLE
Display SSH prompts interactively DURING bootstrap

### DIFF
--- a/straight-x.el
+++ b/straight-x.el
@@ -152,7 +152,7 @@
   (let ((lockfile-path (straight--versions-lockfile 'pinned)))
     (with-temp-file lockfile-path
       (insert
-       (format "(%s)\n:delta\n"
+       (format "(%s)\n:epsilon\n"
                (mapconcat
                 (apply-partially #'format "%S")
                 straight-x-pinned-packages

--- a/straight.el
+++ b/straight.el
@@ -7007,7 +7007,7 @@ according to the value of `straight-profiles'."
               ;;
               ;; The version keyword comes after the versions alist so
               ;; that you can ignore it if you don't need it.
-              "(%s)\n:delta\n"
+              "(%s)\n:epsilon\n"
               (mapconcat
                (apply-partially #'format "%S")
                versions-alist


### PR DESCRIPTION
Daisy-chain #1207 out of the bootstrap Emacs subprocess, so that you can even do this now:

```elisp
(setq straight-repository-branch "develop")
(setq straight-display-subprocess-prompts t)
(setq straight-vc-git-default-protocol 'ssh)

(defvar bootstrap-version)
(let ((bootstrap-file
       (expand-file-name
        "straight/repos/straight.el/bootstrap.el"
        (or (bound-and-true-p straight-base-dir)
            user-emacs-directory)))
      (bootstrap-version 7))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))
```

And it will correctly prompt you interactively for your SSH passphrase in the minibuffer. Pretty cool right?