### PR TITLE
Use lexical-binding when loading entries from autoloads cache

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6255,7 +6255,7 @@ RECIPE is a straight.el-style plist."
                 (current-load-list nil))
             ;; car is the feature list, cdr is the autoloads.
             (dolist (form (cdr (gethash package straight--autoloads-cache)))
-              (eval form))
+              (eval form t))
             (when current-load-list
               (push (cons load-file-name current-load-list) load-history))))
       (straight--load-package-autoloads package))))


### PR DESCRIPTION
straight--activate-package-autoloads: Use lexical bindings

Autoload files use lexical bindings and as a result some packages
actually depend on that.  So we need to use lexical bindings when
evaluating entries from the autoloads cache.

For an example see https://github.com/magit/magit/issues/5476.

Ps: The contributor guide told me to update `CHANGELOG.md`.  I would have done that, but I could not find that file.