### PR TITLE
Fix a symlink bug on Windows where mklink would fail for a name ending in `=`

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -1084,8 +1084,8 @@ be interpreted later as a symlink."
             (if (straight--windows-os-p)
                 (straight--process-output
                  "cmd" "/c" "mklink"
-                 (subst-char-in-string ?/ ?\\ link-name)
-                 (subst-char-in-string ?/ ?\\ link-target))
+                 (concat (subst-char-in-string ?/ ?\\ link-name) " ")
+                 (concat (subst-char-in-string ?/ ?\\ link-target) " "))
               (make-symbolic-link link-target link-name))
           (copy-file link-target link-name)
           (let ((build-dir (straight--build-dir)))

--- a/straight.el
+++ b/straight.el
@@ -1082,10 +1082,11 @@ be interpreted later as a symlink."
     (condition-case _
         (if straight-use-symlinks
             (if (straight--windows-os-p)
-                (straight--process-output
-                 "cmd" "/c" "mklink"
-                 (concat (subst-char-in-string ?/ ?\\ link-name) " ")
-                 (concat (subst-char-in-string ?/ ?\\ link-target) " "))
+                (let ((w32-quote-process-args nil))
+                  (straight--process-output
+                   "cmd" "/c" "mklink"
+                   (format "\"%s\"" (subst-char-in-string ?/ ?\\ link-name))
+                   (format "\"%s\"" (subst-char-in-string ?/ ?\\ link-target))))
               (make-symbolic-link link-target link-name))
           (copy-file link-target link-name)
           (let ((build-dir (straight--build-dir)))

--- a/straight.el
+++ b/straight.el
@@ -1070,6 +1070,7 @@ If `straight-use-symlinks' is nil, then instead of creating a
 symlink, the file is copied directly, and a corresponding entry
 is created in the straight/links/ directory so that the file may
 be interpreted later as a symlink."
+  (defvar w32-quote-process-args)
   (if (and (file-directory-p link-target)
            (not (file-symlink-p link-target)))
       (progn
@@ -1085,8 +1086,10 @@ be interpreted later as a symlink."
                 (let ((w32-quote-process-args nil))
                   (straight--process-output
                    "cmd" "/c" "mklink"
-                   (format "\"%s\"" (subst-char-in-string ?/ ?\\ link-name))
-                   (format "\"%s\"" (subst-char-in-string ?/ ?\\ link-target))))
+                   (format
+                    "\"%s\"" (subst-char-in-string ?/ ?\\ link-name))
+                   (format
+                    "\"%s\"" (subst-char-in-string ?/ ?\\ link-target))))
               (make-symbolic-link link-target link-name))
           (copy-file link-target link-name)
           (let ((build-dir (straight--build-dir)))


### PR DESCRIPTION
Firstly, thank you for all your work, straight.el is great!

This is a small fix for a bug I've encountered on Windows with symlinking. It's a bit of a crap fix because I haven't had the time to look properly at it to understand what's going on. I'm posting this mostly in case it helps others and perhaps someone can improve the fix or at least explain what's going on. Please do feel free just to close this PR on the basis that it's not well motivated.

When installing yasnippt-snippets I would see the following output:

```
$ cd "c:/Users/dave/source/dgchurchill/dotfiles/emacs/"
$ "cmd" "/c" "mklink" "c:\Users\dave\.config\emacs\straight\build-30.2\yasnippet-snippets\snippets\rust-mode\cfg=" "c:\Users\dave\.config\emacs\straight\repos\yasnippet-snippets\snippets\rust-mode\cfg="

symbolic link created for c:\Users\dave\.config\emacs\straight\build-30.2\yasnippet-snippets\snippets\rust-mode\cfg <<===>> c:\Users\dave\.config\emacs\straight\repos\yasnippet-snippets\snippets\rust-mode\cfg

[Return code: 0]

$ cd "c:/Users/dave/source/dgchurchill/dotfiles/emacs/"
$ "cmd" "/c" "mklink" "c:\Users\dave\.config\emacs\straight\build-30.2\yasnippet-snippets\snippets\rust-mode\cfg" "c:\Users\dave\.config\emacs\straight\repos\yasnippet-snippets\snippets\rust-mode\cfg"

Cannot create a file when that file already exists.

[Return code: 1]
```

For some reason, when creating the link to `cfg=` the `=` would be stripped off the end and I'd get a link from `cfg` to `cfg`. Maybe this is related to quoting but I'm not really sure.

For whatever reason, appending a space to the end of the names makes everything work correctly.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/radian-software/contributor-guide>

Please create pull requests against the develop branch only!

-->
