### PR TITLE
allow elpa/ directory to exist if there are no actual packages in it

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -7472,13 +7472,17 @@ Must be set before bootstrap."))
         (setq straight-package--warning-displayed t))
     (with-eval-after-load 'package
       (unless straight-package--warning-displayed
-        (when (file-exists-p (bound-and-true-p package-user-dir))
-          (display-warning
-           '(straight package)
-           (concat
-            "package.el was loaded when straight.el was already loaded. "
-            tips)
-           :warning))
+        (let* ((user-dir (bound-and-true-p package-user-dir))
+               (files (when (file-exists-p user-dir)
+                        (directory-files user-dir nil "[:alnum]")))
+               (packages (delete "archives" (delete "gnupg" files))))
+          (when packages
+            (display-warning
+             '(straight package)
+             (concat
+              "package.el was loaded when straight.el was already loaded. "
+              tips)
+             :warning)))
         (setq straight-package--warning-displayed t)))))
 
 ;;;;;; Mode variables

--- a/straight.el
+++ b/straight.el
@@ -7474,7 +7474,7 @@ Must be set before bootstrap."))
       (unless straight-package--warning-displayed
         (let* ((user-dir (bound-and-true-p package-user-dir))
                (files (when (file-exists-p user-dir)
-                        (directory-files user-dir nil "[:alnum]")))
+                        (directory-files user-dir nil "^[^.]")))
                (packages (delete "archives" (delete "gnupg" files))))
           (when packages
             (display-warning


### PR DESCRIPTION
Currently straight.el does not provide alternatives to package.el's `describe-package` or `list-packages`, so users are forced to use those if they are interested in that feature. However, configuring package.el to retrieve all the packages from Elpa and Melpa will result in the `.emacs.d/elpa` directory being created, which straight.el doesn't like because it thinks it means the user is mixing package managers.

With this PR straight.el would allow that directory to exist, as long as there are no packages installed inside, which is the actual sign that the package managers are being mixed.