### PR TITLE
More correct package-enable-at-startup check

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -7464,30 +7464,20 @@ Must be set before bootstrap."))
             (abbreviate-file-name early-init-file)
           "~/.emacs.d/early-init.el"))))
   (if (and (featurep 'package)
-           package-enable-at-startup
-           (file-exists-p (bound-and-true-p package-user-dir)))
-      (unless straight-package--warning-displayed
-        (display-warning
-         '(straight package)
-         (concat
-          "straight.el was loaded when package.el was already loaded. "
-          tips)
-         :warning)
-        (setq straight-package--warning-displayed t))
-    (with-eval-after-load 'package
-      (unless straight-package--warning-displayed
-        (let* ((user-dir (bound-and-true-p package-user-dir))
-               (files (when (file-exists-p user-dir)
-                        (directory-files user-dir nil "^[^.]")))
-               (packages (delete "archives" (delete "gnupg" files))))
-          (when packages
+           package-enable-at-startup)
+      (let ((user-dir (bound-and-true-p package-user-dir))
+            (files (when (file-exists-p user-dir)
+                     (directory-files user-dir nil "^[^.]")))
+            (packages (delete "archives" (delete "gnupg" files))))
+        (when packages
+          (unless straight-package--warning-displayed
             (display-warning
              '(straight package)
              (concat
-              "package.el was loaded when straight.el was already loaded. "
+              "straight.el was loaded when package.el was already loaded. "
               tips)
-             :warning)))
-        (setq straight-package--warning-displayed t)))))
+             :warning)
+            (setq straight-package--warning-displayed t))))))
 
 ;;;;;; Mode variables
 

--- a/straight.el
+++ b/straight.el
@@ -7465,10 +7465,10 @@ Must be set before bootstrap."))
           "~/.emacs.d/early-init.el"))))
   (if (and (featurep 'package)
            package-enable-at-startup)
-      (let ((user-dir (bound-and-true-p package-user-dir))
-            (files (when (file-exists-p user-dir)
-                     (directory-files user-dir nil "^[^.]")))
-            (packages (delete "archives" (delete "gnupg" files))))
+      (let* ((user-dir (bound-and-true-p package-user-dir))
+             (files (when (file-exists-p user-dir)
+                      (directory-files user-dir nil "^[^.]")))
+             (packages (delete "archives" (delete "gnupg" files))))
         (when packages
           (unless straight-package--warning-displayed
             (display-warning


### PR DESCRIPTION
It's fine to load `package.el`, actually. The loading isn't the problem, but rather the package activation, which requires a special function call. That function call was done by the user's init-file in the past, which was why `package.el` used to try and edit the user's init-file, but that functionality was removed due to my efforts, so now the function call happens in `startup.el`, between loading the two init-files.

So - loading `package.el` isn't the problem. Only that function call that happens in `startup.el` is a problem. That function call only happens if `package-enable-at-startup` is non-nil. By default, `straight.el` will disable `package-enable-at-startup` itself, so in the case that `straight.el` is loaded during early-init, then it's solved the problem, no need to worry about checking later. (The user could customize things to undo or prevent `straight.el` fixing things, but then it's their own fault.)

On the other hand, if `straight.el` is loaded after early-init, then what we should check to get a pretty good guess about whether package activation happened is: is `package-enable-at-startup` enabled, and there are some packages on disk? If so, then probably it happened. Signal a warning.

We can therefore get rid of the whole case about `package.el` being loaded after `straight.el`, because that's not actually a problem, at least by default. It at the very least needed to be conditioned on `package-enable-at-startup` to avoid serious false positives, but the whole check isn't needed in the first place really.

Also, take some more fine-grained logic about checking that there really is at least one installed package, and move it from the one check to the other check, where it is also useful to avoid false positives.
